### PR TITLE
Added feature for showing Ecosystem name in the table along with othe…

### DIFF
--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -234,7 +234,6 @@ func (r *summaryReporter) renderRemediationAdvice() {
 
 	fmt.Println(text.Bold.Sprint("Consider upgrading the following libraries for maximum impact:"))
 	fmt.Println()
-	// fmt.Println(sortedPackages)
 	tbl := table.NewWriter()
 	tbl.SetOutputMirror(os.Stdout)
 	tbl.SetStyle(table.StyleLight)

--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -251,6 +251,7 @@ func (r *summaryReporter) renderRemediationAdvice() {
 			r.packageNameForRemediationAdvice(sp.pkg),
 			utils.SafelyGetValue(insight.PackageCurrentVersion),
 			sp.score,
+			r.packageNameForRemediationAdvice(sp.ecosystem),
 		})
 
 		tagText := ""

--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -234,22 +234,22 @@ func (r *summaryReporter) renderRemediationAdvice() {
 
 	fmt.Println(text.Bold.Sprint("Consider upgrading the following libraries for maximum impact:"))
 	fmt.Println()
-
+	// fmt.Println(sortedPackages)
 	tbl := table.NewWriter()
 	tbl.SetOutputMirror(os.Stdout)
 	tbl.SetStyle(table.StyleLight)
 
-	tbl.AppendHeader(table.Row{"Package", "Update To", "Impact"})
+	tbl.AppendHeader(table.Row{"Package", "Ecosystem", "Update To", "Impact"})
 	for idx, sp := range sortedPackages {
 		if idx >= summaryReportMaxUpgradeAdvice {
 			break
 		}
 
 		insight := utils.SafelyGetValue(sp.pkg.Insights)
-
+		
 		tbl.AppendRow(table.Row{
-			sp.ecosystem,
 			r.packageNameForRemediationAdvice(sp.pkg),
+			sp.pkg.Manifest.Ecosystem,
 			utils.SafelyGetValue(insight.PackageCurrentVersion),
 			sp.score,
 		

--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -248,10 +248,11 @@ func (r *summaryReporter) renderRemediationAdvice() {
 		insight := utils.SafelyGetValue(sp.pkg.Insights)
 
 		tbl.AppendRow(table.Row{
+			sp.ecosystem,
 			r.packageNameForRemediationAdvice(sp.pkg),
 			utils.SafelyGetValue(insight.PackageCurrentVersion),
 			sp.score,
-			r.packageNameForRemediationAdvice(sp.ecosystem),
+		
 		})
 
 		tagText := ""


### PR DESCRIPTION

Issue description:

The summary reporter presents a table of packages that are recommended for upgrade. It does not show the ecosystem of the package and only shows the name and version. While this is fine for a scan where only a single lockfile was scanned, this is a problem where multiple lockfiles were scanned with different ecosystem

Screenshot-2023-04-09-170817

To start improving the UX, we should start by showing the Ecosystem name in the report report table.






Let me know if there are any changes instead of closing this PR.

What is drift I don't know I kept as it is.

#54 
![image](https://user-images.githubusercontent.com/55488549/230795394-1a0b6a80-9834-420f-873a-abe4cb6c8f17.png)
