### PR TITLE
feat: Scan Manifest on Discovery

### DIFF
--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -68,7 +68,7 @@ func IncrementTrackerTotal(i any, count int64) {
 
 func IncrementProgress(i any, count int64) {
 	if tracker, ok := i.(*progress.Tracker); ok && (progressTrackerDelta(tracker) > count) {
-		tracker.Increment(int64(count))
+		tracker.Increment(count)
 	}
 }
 

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -12,6 +12,7 @@ var progressWriter progress.Writer
 func StartProgressWriter() {
 	pw := progress.NewWriter()
 
+	pw.SetAutoStop(false)
 	pw.SetTrackerLength(25)
 	pw.SetMessageWidth(20)
 	pw.SetSortBy(progress.SortByPercentDsc)
@@ -36,6 +37,12 @@ func StopProgressWriter() {
 	}
 }
 
+func SetPinnedMessageOnProgressWriter(msg string) {
+	if progressWriter != nil {
+		progressWriter.SetPinnedMessages(msg)
+	}
+}
+
 func TrackProgress(message string, total int) any {
 	tracker := progress.Tracker{Message: message, Total: int64(total),
 		Units: progress.UnitsDefault}
@@ -53,14 +60,18 @@ func MarkTrackerAsDone(i any) {
 	}
 }
 
-func IncrementTrackerTotal(i any, count int) {
+func IncrementTrackerTotal(i any, count int64) {
 	if tracker, ok := i.(*progress.Tracker); ok {
-		tracker.UpdateTotal(tracker.Total + int64(count))
+		tracker.UpdateTotal(tracker.Total + count)
 	}
 }
 
-func IncrementProgress(i any, count int) {
-	if tracker, ok := i.(*progress.Tracker); ok {
+func IncrementProgress(i any, count int64) {
+	if tracker, ok := i.(*progress.Tracker); ok && (progressTrackerDelta(tracker) > count) {
 		tracker.Increment(int64(count))
 	}
+}
+
+func progressTrackerDelta(tracker *progress.Tracker) int64 {
+	return (tracker.Total - tracker.Value())
 }

--- a/pkg/analyzer/cel_filter.go
+++ b/pkg/analyzer/cel_filter.go
@@ -121,7 +121,7 @@ func (f *celFilterAnalyzer) notifyCaller(manifest *models.PackageManifest,
 			Type:     ET_AnalyzerFailOnError,
 			Manifest: manifest,
 			Err: fmt.Errorf("failed due to filter match on %s",
-				manifest.Path),
+				manifest.GetDisplayPath()),
 		})
 	}
 

--- a/pkg/analyzer/cel_filter_suite.go
+++ b/pkg/analyzer/cel_filter_suite.go
@@ -89,7 +89,7 @@ func (f *celFilterSuiteAnalyzer) Analyze(manifest *models.PackageManifest,
 			Source:   f.Name(),
 			Type:     ET_AnalyzerFailOnError,
 			Manifest: manifest,
-			Err:      fmt.Errorf("failed due to filter suite match on %s", manifest.Path),
+			Err:      fmt.Errorf("failed due to filter suite match on %s", manifest.GetDisplayPath()),
 		})
 	}
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -82,6 +82,10 @@ func (pm *PackageManifest) Id() string {
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 
+func (pm *PackageManifest) GetPackagesCount() int {
+	return len(pm.Packages)
+}
+
 func (pm *PackageManifest) GetSpecEcosystem() modelspec.Ecosystem {
 	switch pm.Ecosystem {
 	case EcosystemCargo:

--- a/pkg/scanner/callbacks.go
+++ b/pkg/scanner/callbacks.go
@@ -2,8 +2,6 @@ package scanner
 
 import "github.com/safedep/vet/pkg/models"
 
-type ScannerCallbackOnManifestsFn func(manifest []*models.PackageManifest)
-
 type ScannerCallbackOnManifestFn func(manifest *models.PackageManifest)
 
 type ScannerCallbackOnPackageFn func(pkg *models.Package)
@@ -13,16 +11,16 @@ type ScannerCallbackErrArgFn func(error)
 type ScannerCallbackNoArgFn func()
 
 type ScannerCallbacks struct {
-	OnStartEnumerateManifest ScannerCallbackNoArgFn       // Manifest enumeration is starting
-	OnEnumerateManifest      ScannerCallbackOnManifestFn  // A manifest is read by reader
-	OnStart                  ScannerCallbackOnManifestsFn // Manifest scan phase is starting
-	OnStartManifest          ScannerCallbackOnManifestFn  // A manifest is starting to be scanned
-	OnStartPackage           ScannerCallbackOnPackageFn   // A package analysis is starting
-	OnAddTransitivePackage   ScannerCallbackOnPackageFn   // A transitive dependency is discovered
-	OnDonePackage            ScannerCallbackOnPackageFn   // A package analysis is finished
-	OnDoneManifest           ScannerCallbackOnManifestFn  // A manifest analysis is finished
-	BeforeFinish             ScannerCallbackNoArgFn       // Scan is about to finish
-	OnStop                   ScannerCallbackErrArgFn      // Scan is finished
+	OnStartEnumerateManifest ScannerCallbackNoArgFn      // Manifest enumeration is starting
+	OnEnumerateManifest      ScannerCallbackOnManifestFn // A manifest is read by reader
+	OnStart                  ScannerCallbackNoArgFn      // Manifest scan phase is starting
+	OnStartManifest          ScannerCallbackOnManifestFn // A manifest is starting to be scanned
+	OnStartPackage           ScannerCallbackOnPackageFn  // A package analysis is starting
+	OnAddTransitivePackage   ScannerCallbackOnPackageFn  // A transitive dependency is discovered
+	OnDonePackage            ScannerCallbackOnPackageFn  // A package analysis is finished
+	OnDoneManifest           ScannerCallbackOnManifestFn // A manifest analysis is finished
+	BeforeFinish             ScannerCallbackNoArgFn      // Scan is about to finish
+	OnStop                   ScannerCallbackErrArgFn     // Scan is finished
 }
 
 func (s *packageManifestScanner) WithCallbacks(callbacks ScannerCallbacks) {
@@ -41,9 +39,9 @@ func (s *packageManifestScanner) dispatchOnManifestEnumeration(manifest *models.
 	}
 }
 
-func (s *packageManifestScanner) dispatchOnStart(manifests []*models.PackageManifest) {
+func (s *packageManifestScanner) dispatchOnStart() {
 	if s.callbacks.OnStart != nil {
-		s.callbacks.OnStart(manifests)
+		s.callbacks.OnStart()
 	}
 }
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -118,32 +118,28 @@ func (s *packageManifestScanner) startManifestScanner(ctx context.Context,
 
 		s.dispatchOnStartManifest(manifest)
 
-		// We are using a function here so that we can use `defer` to ensure
-		// we always mark the wait group irrespective of success or failure
-		func() {
-			// Enrich each packages in a manifest with metadata
-			err := s.enrichManifest(manifest)
-			if err != nil {
-				logger.Errorf("Failed to enrich %s manifest %s : %v",
-					manifest.Ecosystem, manifest.GetPath(), err)
-			}
+		// Enrich each packages in a manifest with metadata
+		err := s.enrichManifest(manifest)
+		if err != nil {
+			logger.Errorf("Failed to enrich %s manifest %s : %v",
+				manifest.Ecosystem, manifest.GetPath(), err)
+		}
 
-			// Invoke analyzers to analyse the manifest
-			err = s.analyzeManifest(manifest)
-			if err != nil {
-				logger.Errorf("Failed to analyze %s manifest %s : %v",
-					manifest.Ecosystem, manifest.GetPath(), err)
-			}
+		// Invoke analyzers to analyse the manifest
+		err = s.analyzeManifest(manifest)
+		if err != nil {
+			logger.Errorf("Failed to analyze %s manifest %s : %v",
+				manifest.Ecosystem, manifest.GetPath(), err)
+		}
 
-			// Invoke activated reporting modules to report on the manifest
-			err = s.reportManifest(manifest)
-			if err != nil {
-				logger.Errorf("Failed to report %s manifest %s : %v",
-					manifest.Ecosystem, manifest.GetPath(), err)
-			}
+		// Invoke activated reporting modules to report on the manifest
+		err = s.reportManifest(manifest)
+		if err != nil {
+			logger.Errorf("Failed to report %s manifest %s : %v",
+				manifest.Ecosystem, manifest.GetPath(), err)
+		}
 
-			s.dispatchOnDoneManifest(manifest)
-		}()
+		s.dispatchOnDoneManifest(manifest)
 	}
 }
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -50,10 +50,8 @@ func (s *packageManifestScanner) Start() error {
 	// The manifest processing go routine will close the doneChannel
 	doneChannel := make(chan bool)
 
-	scannerChannel := make(chan *models.PackageManifest, 100)
-
 	// We will close the scanner channel
-	defer close(scannerChannel)
+	scannerChannel := make(chan *models.PackageManifest, 100)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -76,6 +74,10 @@ func (s *packageManifestScanner) Start() error {
 			return err
 		}
 	}
+
+	// Close this channel so that go routine processing the manifests
+	// can break the loop
+	close(scannerChannel)
 
 	// Wait for manifest scanner to finish
 	<-doneChannel

--- a/scan.go
+++ b/scan.go
@@ -302,8 +302,17 @@ func internalStartScan() error {
 		reporters = append(reporters, rp)
 	}
 
+	insightsEnricher, err := scanner.NewInsightBasedPackageEnricher(scanner.InsightsBasedPackageMetaEnricherConfig{
+		ApiUrl:     auth.ApiUrl(),
+		ApiAuthKey: auth.ApiKey(),
+	})
+
+	if err != nil {
+		return err
+	}
+
 	enrichers := []scanner.PackageMetaEnricher{
-		scanner.NewInsightBasedPackageEnricher(),
+		insightsEnricher,
 	}
 
 	pmScanner := scanner.NewPackageManifestScanner(scanner.Config{
@@ -322,25 +331,22 @@ func internalStartScan() error {
 
 	pmScanner.WithCallbacks(scanner.ScannerCallbacks{
 		OnStartEnumerateManifest: func() {
-			ui.PrintMsg("Starting to enumerate manifests")
+			logger.Infof("Starting to enumerate manifests")
 		},
 		OnEnumerateManifest: func(manifest *models.PackageManifest) {
-			ui.PrintSuccess("Discovered a manifest at %s with %d packages",
-				manifest.GetDisplayPath(), len(manifest.Packages))
+			logger.Infof("Discovered a manifest at %s with %d packages",
+				manifest.GetDisplayPath(), manifest.GetPackagesCount())
+
+			ui.IncrementTrackerTotal(packageManifestTracker, 1)
+			ui.IncrementTrackerTotal(packageTracker, manifest.GetPackagesCount())
 		},
-		OnStart: func(manifests []*models.PackageManifest) {
+		OnStart: func() {
 			if !silentScan {
 				ui.StartProgressWriter()
 			}
 
-			var tm, tp int
-			for _, m := range manifests {
-				tm += 1
-				tp += len(m.Packages)
-			}
-
-			packageManifestTracker = ui.TrackProgress("Scanning manifests", tm)
-			packageTracker = ui.TrackProgress("Scanning packages", tp)
+			packageManifestTracker = ui.TrackProgress("Scanning manifests", 0)
+			packageTracker = ui.TrackProgress("Scanning packages", 0)
 		},
 		OnAddTransitivePackage: func(pkg *models.Package) {
 			ui.IncrementTrackerTotal(packageTracker, 1)

--- a/scan.go
+++ b/scan.go
@@ -329,6 +329,7 @@ func internalStartScan() error {
 	var packageManifestTracker any
 	var packageTracker any
 
+	manifestsCount := 0
 	pmScanner.WithCallbacks(scanner.ScannerCallbacks{
 		OnStartEnumerateManifest: func() {
 			logger.Infof("Starting to enumerate manifests")
@@ -338,7 +339,11 @@ func internalStartScan() error {
 				manifest.GetDisplayPath(), manifest.GetPackagesCount())
 
 			ui.IncrementTrackerTotal(packageManifestTracker, 1)
-			ui.IncrementTrackerTotal(packageTracker, manifest.GetPackagesCount())
+			ui.IncrementTrackerTotal(packageTracker, int64(manifest.GetPackagesCount()))
+
+			manifestsCount = manifestsCount + 1
+			ui.SetPinnedMessageOnProgressWriter(fmt.Sprintf("Scanning %d discovered manifest(s)",
+				manifestsCount))
 		},
 		OnStart: func() {
 			if !silentScan {

--- a/test/scenarios/all.sh
+++ b/test/scenarios/all.sh
@@ -10,3 +10,4 @@ $E2E_VET_BINARY auth configure --community
 
 bash $E2E_THIS_DIR/scenario-1-vet-scans-vet.sh
 bash $E2E_THIS_DIR/scenario-2-vet-scan-demo-client-java.sh
+bash $E2E_THIS_DIR/scenario-3-filter-fail-fast.sh

--- a/test/scenarios/scenario-3-filter-fail-fast.sh
+++ b/test/scenarios/scenario-3-filter-fail-fast.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+
+$E2E_VET_BINARY scan -s --no-banner \
+  --github https://github.com/safedep/demo-client-java.git \
+  --report-summary=false \
+  --filter 'vulns.critical.exists(p, p.id == "GHSA-4wrc-f8pq-fpqp")' \
+  --filter-fail || exit 0
+
+exit 1


### PR DESCRIPTION
- Refactor scanner workflow to enable scanning per manifests instead of batching
- fix: Bug with tracker being marked as done
