### PR TITLE
Add 'advices' field to the generated json report file

### DIFF
--- a/pkg/reporter/json_report.go
+++ b/pkg/reporter/json_report.go
@@ -215,9 +215,6 @@ func (r *jsonReportGenerator) buildSpecReport() (*schema.Report, error) {
 }
 
 func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Package) *jsonreportspec.PackageReport {
-
-	flag := true
-	var r *summaryReporter
 	pkg := &jsonreportspec.PackageReport{
 		Package: &modelspec.Package{
 			Ecosystem: p.GetSpecEcosystem(),
@@ -234,9 +231,6 @@ func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Packag
 	insights := utils.SafelyGetValue(p.Insights)
 	vulns := utils.SafelyGetValue(insights.Vulnerabilities)
 	licenses := utils.SafelyGetValue(insights.Licenses)
-	updateToVersion := r.packageUpdateVersionForRemediationAdvice(p)
-
-
 
 	for _, vuln := range vulns {
 		insightSeverities := utils.SafelyGetValue(vuln.Severities)
@@ -264,18 +258,18 @@ func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Packag
 			Severities: severties,
 		})
 
-		if (len(pkg.Vulnerabilities) > 0 && flag) {
-			pkg.Advices = append(pkg.Advices, &schema.RemediationAdvice{
-				Type:					schema.RemediationAdviceType_UpgradePackage,
-				TargetAlternatePackageVersion:		updateToVersion,
-			})
-			flag = false
-
 	}
 
 	for _, license := range licenses {
 		pkg.Licenses = append(pkg.Licenses, &modelspec.InsightLicenseInfo{
 			Id: string(license),
+		})
+	}
+
+	if len(pkg.Vulnerabilities) > 0 {
+		pkg.Advices = append(pkg.Advices, &schema.RemediationAdvice{
+			Type:                          schema.RemediationAdviceType_UpgradePackage,
+			TargetAlternatePackageVersion: utils.SafelyGetValue(insights.PackageCurrentVersion),
 		})
 	}
 

--- a/pkg/reporter/json_report.go
+++ b/pkg/reporter/json_report.go
@@ -215,6 +215,8 @@ func (r *jsonReportGenerator) buildSpecReport() (*schema.Report, error) {
 }
 
 func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Package) *jsonreportspec.PackageReport {
+
+	var r *summaryReporter
 	pkg := &jsonreportspec.PackageReport{
 		Package: &modelspec.Package{
 			Ecosystem: p.GetSpecEcosystem(),
@@ -231,6 +233,9 @@ func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Packag
 	insights := utils.SafelyGetValue(p.Insights)
 	vulns := utils.SafelyGetValue(insights.Vulnerabilities)
 	licenses := utils.SafelyGetValue(insights.Licenses)
+	updateToVersion := r.packageUpdateVersionForRemediationAdvice(p)
+
+
 
 	for _, vuln := range vulns {
 		insightSeverities := utils.SafelyGetValue(vuln.Severities)
@@ -257,6 +262,13 @@ func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Packag
 			Aliases:    utils.SafelyGetValue(vuln.Aliases),
 			Severities: severties,
 		})
+
+		if (len(pkg.Vulnerabilities) > 0) {
+			pkg.Advices = append(pkg.Advices, &schema.RemediationAdvice{
+				TargetAlternatePackageVersion:	updateToVersion,
+			})
+		}
+
 	}
 
 	for _, license := range licenses {

--- a/pkg/reporter/json_report.go
+++ b/pkg/reporter/json_report.go
@@ -216,6 +216,7 @@ func (r *jsonReportGenerator) buildSpecReport() (*schema.Report, error) {
 
 func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Package) *jsonreportspec.PackageReport {
 
+	flag := true
 	var r *summaryReporter
 	pkg := &jsonreportspec.PackageReport{
 		Package: &modelspec.Package{
@@ -263,10 +264,12 @@ func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Packag
 			Severities: severties,
 		})
 
-		if (len(pkg.Vulnerabilities) > 0) {
+		if (len(pkg.Vulnerabilities) > 0 && flag) {
 			pkg.Advices = append(pkg.Advices, &schema.RemediationAdvice{
 				TargetAlternatePackageVersion:	updateToVersion,
 			})
+			flag = false
+
 		}
 
 	}

--- a/pkg/reporter/json_report.go
+++ b/pkg/reporter/json_report.go
@@ -266,11 +266,10 @@ func (j *jsonReportGenerator) buildJsonPackageReportFromPackage(p *models.Packag
 
 		if (len(pkg.Vulnerabilities) > 0 && flag) {
 			pkg.Advices = append(pkg.Advices, &schema.RemediationAdvice{
-				TargetAlternatePackageVersion:	updateToVersion,
+				Type:					schema.RemediationAdviceType_UpgradePackage,
+				TargetAlternatePackageVersion:		updateToVersion,
 			})
 			flag = false
-
-		}
 
 	}
 


### PR DESCRIPTION
Hi

The `--report-json` flag in Vet generated a comprehensive json report file. However, it missed a field that was being displayed in the console output - the 'UPDATE TO' column data, that display what version the package should be upgraded to in order to mitigate the risk.

![image](https://github.com/safedep/vet/assets/38760238/a39d1261-0fc4-4cfe-8dd4-c40388e0c897)

This PR, with a few lines of code, adds 'advices' field to the json report suggesting the alternate package version that the vulnerable package should be upgraded to.

```json
{
    "package":
    {
        "ecosystem": "Maven",
        "name": "com.nimbusds:nimbus-jose-jwt",
        "version": "9.22"
    },
    "manifests":
    [
        "2de911f109118e4d"
    ],
    "advices":
    [
        {
            "target_alternate_package_version": "9.39.1"
        }
    ],
    "vulnerabilities":
    [
        {
            "id": "GHSA-gvpg-vgmx-xg6w",
            "title": "Denial of Service in Connect2id Nimbus JOSE+JWT",
            "aliases":
            [
                "CVE-2023-52428"
            ]
        }
    ],
    "licenses":
    [
        {
            "id": "Apache-2.0"
        }
    ]
}
```

Thanks.