### PR TITLE
docs:  Update tree-sitter parser link for Code Analysis documentation

### DIFF
--- a/docs/docs/guides/code-analysis.md
+++ b/docs/docs/guides/code-analysis.md
@@ -11,7 +11,7 @@ EXPERIMENTAL: This feature is experimental and may introduce breaking changes.
 
 :::
 
-`vet` has a code analysis framework built on top of [tree-sitter](#) parsers. The goal
+`vet` has a code analysis framework built on top of [tree-sitter](https://tree-sitter.github.io/tree-sitter/) parsers. The goal
 of this framework is to support multiple languages, source repositories (local and remote),
 and create a representation of code that can be analysed for common software
 supply chain security related use-cases such as


### PR DESCRIPTION
Update tree-sitter parser link (https://tree-sitter.github.io/tree-sitter/) in Code Analysis documentation. 