### PR TITLE
feat: Rename column "Update To" to "Latest" in remediation advice table

### DIFF
--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -446,7 +446,7 @@ func (r *summaryReporter) renderRemediationAdvice() {
 
 func (r *summaryReporter) addRemediationAdviceTableRows(tbl table.Writer,
 	sortedPackages []*summaryReporterRemediationData, maxAdvice int) {
-	tbl.AppendHeader(table.Row{"Ecosystem", "Package", "Update To", "Impact Score", "Vuln Risk"})
+	tbl.AppendHeader(table.Row{"Ecosystem", "Package", "Latest", "Impact Score", "Vuln Risk"})
 
 	// Re-use the formatting logic within this function boundary
 	formatTags := func(tags []string) string {


### PR DESCRIPTION
## Description:
This PR updates the column name in the `addRemediationAdviceTableRows` function from `Update To` to `Latest` for improved clarity and alignment with the backend data.

## Why this change?
The term `Update To` could be misleading as it doesn't precisely represent the data provided by the backend. By renaming it to `Latest`, the table becomes clearer and more specific for users.

For more context, refer to the discussion in the related issue: [#292  - Unexpected Behavior When Scanning Non-Existing and Latest Versions of npm Packages](https://github.com/safedep/vet/issues/292#issuecomment-2513877159).

![image](https://github.com/user-attachments/assets/8c870162-d72b-421c-9379-be1f398c24de)
