### PR TITLE
feat: Add SLSA tag in summary report when available

### DIFF
--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -300,6 +300,22 @@ func GetModelEcosystem(ecosystem packagev1.Ecosystem) string {
 	}
 }
 
+type ProvenanceType string
+
+const (
+	ProvenanceTypeSlsa = ProvenanceType("slsa")
+)
+
+// Represents an abstract provenance of a package provided
+// by different sources such as deps.dev or other sources
+type Provenance struct {
+	Type             ProvenanceType `json:"type"`
+	CommitSHA        string         `json:"commit_sha"`
+	SourceRepository string         `json:"source_url"`
+	Url              string         `json:"url"`
+	Verified         bool           `json:"verified"`
+}
+
 // Represents a package such as a version of a library defined as a dependency
 // in Gemfile.lock, pom.xml etc.
 type Package struct {
@@ -316,6 +332,9 @@ type Package struct {
 
 	// Depth of this package in dependency tree
 	Depth int `json:"depth"`
+
+	// Optional provenances for this package
+	Provenances []*Provenance `json:"provenances"`
 
 	// Manifest from where this package was found directly or indirectly
 	Manifest *PackageManifest `json:"-"`
@@ -347,6 +366,10 @@ func (p *Package) GetName() string {
 
 func (p *Package) GetVersion() string {
 	return p.Version
+}
+
+func (p *Package) GetProvenances() []*Provenance {
+	return p.Provenances
 }
 
 func (p *Package) ShortName() string {

--- a/test/scenarios/all.sh
+++ b/test/scenarios/all.sh
@@ -16,3 +16,4 @@ bash $E2E_THIS_DIR/scenario-4-lfp-fail-fast.sh
 bash $E2E_THIS_DIR/scenario-5-gradle-depgraph-build.sh
 bash $E2E_THIS_DIR/scenario-6-manifest-flag.sh
 bash $E2E_THIS_DIR/scenario-7-rubygems-project-url.sh
+bash $E2E_THIS_DIR/scenario-8-summary-report.sh

--- a/test/scenarios/scenario-8-summary-report.sh
+++ b/test/scenarios/scenario-8-summary-report.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+if [ "$E2E_VET_INSIGHTS_V2" != "true" ]; then
+  echo "Skipping scenario-8-summary-report.sh as E2E_INSIGHTS_V2 is not set to true"
+  exit 0
+fi
+
+$(echo \
+$E2E_VET_SCAN_CMD \
+  scan --purl pkg:/npm/@clerk/nextjs@6.9.6
+) | grep "slsa: verified"
+


### PR DESCRIPTION
Show `slsa` provenance tag when available. This requires `--insights-v2` because thats the service that is provenance aware.

<img width="1092" alt="Screenshot 2024-12-28 at 10 33 44 AM" src="https://github.com/user-attachments/assets/92a30b2e-1194-40d6-8714-ce73c50fbebc" />


