### PR TITLE
fix: Improve markdown summary report to make malware analysis section collapsable

### DIFF
--- a/pkg/reporter/markdown/emoji.go
+++ b/pkg/reporter/markdown/emoji.go
@@ -1,12 +1,13 @@
 package markdown
 
 const (
-	EmojiArrowRight     = ":arrow_right:"
-	EmojiWhiteCheckMark = ":white_check_mark:"
-	EmojiCrossMark      = ":x:"
-	EmojiLink           = ":link:"
-	EmojiWarning        = ":warning:"
-	EmojiRedExclamation = ":exclamation:"
-	EmojiOrangeCircle   = ":orange_circle:"
-	EmojiRedCircle      = ":red_circle:"
+	EmojiArrowRight        = ":arrow_right:"
+	EmojiWhiteCheckMark    = ":white_check_mark:"
+	EmojiCrossMark         = ":x:"
+	EmojiLink              = ":link:"
+	EmojiWarning           = ":warning:"
+	EmojiRedExclamation    = ":exclamation:"
+	EmojiOrangeCircle      = ":orange_circle:"
+	EmojiRedCircle         = ":red_circle:"
+	EmojiInformationSource = ":information_source:"
 )


### PR DESCRIPTION
Improve markdown summary reporter to make it less verbose. Example: https://github.com/safedep/vet/issues/303#issuecomment-2603699774