### PR TITLE
Exclude patterns option & ensure code DB path exists before preparing Code DB

### DIFF
--- a/pkg/storage/ent_sqlite.go
+++ b/pkg/storage/ent_sqlite.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/safedep/vet/ent"
@@ -27,6 +29,12 @@ func NewEntSqliteStorage(config EntSqliteClientConfig) (Storage[*ent.Client], er
 	mode := "rwc"
 	if config.ReadOnly {
 		mode = "ro"
+	}
+
+	// Ensure the path exists
+	dir := filepath.Dir(config.Path)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to create DB path %s: %w", dir, err)
 	}
 
 	dbConn := fmt.Sprintf("file:%s?mode=%s&cache=private&_fk=1", config.Path, mode)


### PR DESCRIPTION
If user is doing - `vet code scan --db /tmp/a/b/c/dump/vet-test.db` and the intermediate dirs like `/tmp/a`, `/tmp/b` don't exists, vet would panic. This isn't handled by sqlite.
It is fixed using `os.MkdirAll` to ensure all intermediate paths exist.

Added `--exclude` mutli-string flag to skip misleading folders like `test-data/` which may contain dummy source code 
eg. 
```bash
vet code scan --db /tmp/vet-test.db --exclude test-data --exclude .venv
```