### PR TITLE
fix: remove replace directive from go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/owenrumney/go-sarif/v2 v2.3.1 => github.com/safedep/go-sarif/v2 v2.3.1
 
 require (
 	ariga.io/atlas v0.31.0 // indirect


### PR DESCRIPTION
Removed the replace directive from go.mod file as it was causing a issue when running `go install..` command to download the vet binary as mentioned on the README.md file 
```
go install github.com/safedep/vet@latest
```
Below are two issues which discuss about the  error given if `replace` directive is present in `go.mod` file and someone used `go install ..` command to download the binary

https://github.com/golang/go/issues/44840
https://github.com/golang/go/issues/40276


After researching the the solution there where two options to solve this issue. 
1. Using the commit hash directly 
     1.1 But in our case it is not possible the as `github.com/owenrumney/go-sarif/v2` already has a version tag release i.e `v2.3.1`. If we try to use `go get -u ...` command it will still not works as tags are immutable.
2. Vendoring 
    2.1 As we can't vendor the single dependency i.e partial vendoring ..we can't do that (https://github.com/golang/go/issues/52604)


For now we don't need the replace directive as if someone pushed some new commit and re-release the same tag as before that we are using with malicious code. `go get ...` will still fetch the older commit for the tag that was released the reason is golang proxy modules .  By default GOPROXY env variable is set as below 
```
GOPROXY='https://proxy.golang.org,direct'
```
Golang module proxy just stores the modules tag that was fetch first with the new tag so even though someone pushed the malicious commit with same tag it will still fetch the older commits that was release first .

Refer to the below example given by `Matthew Kasun` user in Golang slack channel
https://gophers.slack.com/archives/C02A8LZKT/p1740759851884979
