### PR TITLE
Add ASDF plugin installation steps to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ When contributing changes to repository, follow these steps:
 * Install the development tools
 
 ```bash
+asdf plugin add golang
+asdf plugin add gitleaks
 asdf install
 ```
 
@@ -79,7 +81,7 @@ make quick-vet
 ### Run Tests
 
 ```bash
-go test -v ./...
+make test
 ```
 
 


### PR DESCRIPTION
I tried to download gitleas using `asdf` but it didn't downloaded anything, later after some deep diving i find out we need to add `plugin` of particular tool to install that tool. 

```
asdf plugin add golang
asdf plugin add gitleaks
```