### PR TITLE
fix: missing version  on go install builds

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	runtimeDebug "runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,15 @@ var version string
 var commit string
 
 func newVersionCommand() *cobra.Command {
+	buildInfo, ok := runtimeDebug.ReadBuildInfo()
+
+	if ok && version == "" {
+		// Main.Version is based on the version control system tag or commit.
+		// This useful when app is build with `go install`
+		// See: https://antonz.org/go-1-24/#main-modules-version
+		version = buildInfo.Main.Version
+	}
+
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show version and build information",

--- a/version.go
+++ b/version.go
@@ -8,19 +8,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version string
+// Main.Version is based on the version control system tag or commit.
+// This useful when app is build with `go install`
+// See: https://antonz.org/go-1-24/#main-modules-version
+var buildInfo, _ = runtimeDebug.ReadBuildInfo()
+
+// When building with CI or Make, version is set using `ldflags` but when building with `go install`
+// it will be set on runtime using VCS TAG AND COMMITS
+var version = buildInfo.Main.Version
 var commit string
 
 func newVersionCommand() *cobra.Command {
-	buildInfo, ok := runtimeDebug.ReadBuildInfo()
-
-	if ok && version == "" {
-		// Main.Version is based on the version control system tag or commit.
-		// This useful when app is build with `go install`
-		// See: https://antonz.org/go-1-24/#main-modules-version
-		version = buildInfo.Main.Version
-	}
-
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show version and build information",

--- a/version.go
+++ b/version.go
@@ -8,15 +8,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Main.Version is based on the version control system tag or commit.
-// This useful when app is build with `go install`
-// See: https://antonz.org/go-1-24/#main-modules-version
-var buildInfo, _ = runtimeDebug.ReadBuildInfo()
-
-// When building with CI or Make, version is set using `ldflags` but when building with `go install`
-// it will be set on runtime using VCS TAG AND COMMITS
-var version = buildInfo.Main.Version
+// When building with CI or Make, version is set using `ldflags`
+var version string
 var commit string
+
+func init() {
+	// Only use buildInfo if version wasn't set by ldflags, that is its being build by `go install`
+	if version == "" {
+		// Main.Version is based on the version control system tag or commit.
+		// This useful when app is build with `go install`
+		// See: https://antonz.org/go-1-24/#main-modules-version
+		var buildInfo, _ = runtimeDebug.ReadBuildInfo()
+		version = buildInfo.Main.Version
+	}
+}
 
 func newVersionCommand() *cobra.Command {
 	cmd := &cobra.Command{


### PR DESCRIPTION
Fixes #385 

This solution is based on new go 1.24 feature: https://antonz.org/go-1-24/#main-modules-version

When app is build using `go install` then we will not be able to do `-ldflags`, hence our `version` will be `""`. In that case we will return version using `runtime/debugs`'s BuildInfo. 

Its value will be:

When the current commit matches a tagged version, the value is set to v<tag>[+dirty]:
```bash
v1.2.4
v1.2.4+dirty
```
When the current commit doesn't match a tagged version, the value is set to <pseudo>[+dirty], where pseudo consists of the latest tag, current date, and commit:
```bash
v1.2.3-0.20240620130020-daa7c0413123
v1.2.3-0.20240620130020-daa7c0413123+dirty
```