### PR TITLE
fix: missing shell for using vet's image as environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV CGO_ENABLED=1
 
 RUN make quick-vet
 
-FROM gcr.io/distroless/cc
+FROM debian:bullseye-slim
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
`debian:bullseye-slim` is very small, 80 MB, and current docker image is also near 80 MB.

This is critically needed as, Gitlab need image to `run as shell` for executing commands, like `vet scan` but current docker image being distroless does not have shell (sh). 



![image](https://github.com/user-attachments/assets/4faccccb-837a-4c7a-a4b6-7aee7a0ebf34)
