### PR TITLE
fix: use of default non-root user outside distroless images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN make quick-vet
 
 FROM debian:bullseye-slim
 
+# Create nonroot user and group with specific IDs
+RUN groupadd -r nonroot --gid=65532 && \
+    useradd -r -g nonroot --uid=65532 nonroot
+
+USER nonroot:nonroot
+
 ARG TARGETPLATFORM
 
 LABEL org.opencontainers.image.source=https://github.com/safedep/vet
@@ -22,7 +28,5 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 
 COPY ./samples/ /vet/samples
 COPY --from=build /build/vet /usr/local/bin/vet
-
-USER nonroot:nonroot
 
 ENTRYPOINT ["vet"]


### PR DESCRIPTION
> In previous pr, due to my mistake i didn't tested the new dockerfile locally. 

`nonroot` is not defined in debian, its only by default available in distroless images. So to adhere best practices, i have created a non-root user, this will fix the issue. 