### PR TITLE
fix: error code in vet version command

### DIFF
--- a/version.go
+++ b/version.go
@@ -9,8 +9,10 @@ import (
 )
 
 // When building with CI or Make, version is set using `ldflags`
-var version string
-var commit string
+var (
+	version string
+	commit  string
+)
 
 func init() {
 	// Only use buildInfo if version wasn't set by ldflags, that is its being build by `go install`
@@ -18,7 +20,7 @@ func init() {
 		// Main.Version is based on the version control system tag or commit.
 		// This useful when app is build with `go install`
 		// See: https://antonz.org/go-1-24/#main-modules-version
-		var buildInfo, _ = runtimeDebug.ReadBuildInfo()
+		buildInfo, _ := runtimeDebug.ReadBuildInfo()
 		version = buildInfo.Main.Version
 	}
 }
@@ -31,7 +33,6 @@ func newVersionCommand() *cobra.Command {
 			fmt.Fprintf(os.Stdout, "Version: %s\n", version)
 			fmt.Fprintf(os.Stdout, "CommitSHA: %s\n", commit)
 
-			os.Exit(1)
 			return nil
 		},
 	}


### PR DESCRIPTION
i removed `os.Exit(1)` as `vet version` being successfully execured should exit with status code `0` which is default, that why no `os.exit(0)`. 