### PR TITLE
feat: add excludeRepos support to GithubOrgReader

### DIFF
--- a/pkg/readers/github_org_reader.go
+++ b/pkg/readers/github_org_reader.go
@@ -132,7 +132,7 @@ func (p *githubOrgReader) handleRepositoryBatch(repositories []*github.Repositor
 	for _, repo := range repositories {
 		fullName := repo.GetFullName()
 
-		if isExcludedRepo(fullName, p.config.ExcludeRepos) {
+		if githubIsExcludedRepo(fullName, p.config.ExcludeRepos) {
 			logger.Infof("Skipping excluded repo: %s", fullName)
 			continue
 		}
@@ -182,13 +182,12 @@ func githubOrgFromURL(githubUrl string) (string, error) {
 }
 
 // To exclude specific repo using github org scanner
-func isExcludedRepo(repoName string, excludeCsv string) bool {
-	if excludeCsv == "" {
+func githubIsExcludedRepo(repoName string, excludedRepositories []string) bool {
+	if len(excludedRepositories) == 0 {
 		return false
 	}
 
-	excludeList := strings.Split(excludeCsv, ",")
-	for _, ex := range excludeList {
+	for _, ex := range excludedRepositories {
 		if strings.TrimSpace(repoName) == strings.TrimSpace(ex) {
 			return true
 		}

--- a/pkg/readers/github_org_reader.go
+++ b/pkg/readers/github_org_reader.go
@@ -21,7 +21,7 @@ type GithubOrgReaderConfig struct {
 	IncludeArchived        bool
 	MaxRepositories        int
 	SkipDependencyGraphAPI bool
-	ExcludeRepos           string
+	ExcludeRepos           []string
 }
 
 type githubOrgReader struct {

--- a/pkg/readers/github_org_reader.go
+++ b/pkg/readers/github_org_reader.go
@@ -131,7 +131,6 @@ func (p *githubOrgReader) handleRepositoryBatch(repositories []*github.Repositor
 
 	for _, repo := range repositories {
 		fullName := repo.GetFullName()
-
 		if githubIsExcludedRepo(fullName, p.config.ExcludeRepos) {
 			logger.Infof("Skipping excluded repo: %s", fullName)
 			continue
@@ -187,10 +186,13 @@ func githubIsExcludedRepo(repoName string, excludedRepositories []string) bool {
 		return false
 	}
 
+	logger.Debugf("Checking if repo %s is excluded", repoName)
+
 	for _, ex := range excludedRepositories {
 		if strings.TrimSpace(repoName) == strings.TrimSpace(ex) {
 			return true
 		}
 	}
+
 	return false
 }

--- a/pkg/readers/github_org_reader_test.go
+++ b/pkg/readers/github_org_reader_test.go
@@ -77,4 +77,46 @@ func TestGithubOrgReader(t *testing.T) {
 			}
 		})
 	}
+	
+}
+
+func TestGithubIsExcludedRepo(t *testing.T) {
+	cases := []struct {
+		name        string
+		fullName    string
+		excluded    []string
+		expectedVal bool
+	}{
+		{
+			name:        "no excluded repo configured",
+			fullName:    "x/y",
+			excluded:    []string{},
+			expectedVal: false,
+		},
+		{
+			name:        "match excluded",
+			fullName:    "x/y",
+			excluded:    []string{"y/z", "x/y"},
+			expectedVal: true,
+		},
+		{
+			name:        "match with ignore whitespace",
+			fullName:    "x/y",
+			excluded:    []string{"  x/y  ", "b", "c"},
+			expectedVal: true,
+		},
+		{
+			name:        "no match",
+			fullName:    "x/u",
+			excluded:    []string{"x/y"},
+			expectedVal: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ret := githubIsExcludedRepo(tc.fullName, tc.excluded)
+			assert.Equal(t, tc.expectedVal, ret)
+		})
+	}
 }

--- a/scan.go
+++ b/scan.go
@@ -368,6 +368,7 @@ func internalStartScan() error {
 			IncludeArchived:        false,
 			MaxRepositories:        githubOrgMaxRepositories,
 			SkipDependencyGraphAPI: githubSkipDependencyGraphAPI,
+			ExcludeRepos:           githubOrgExcludedRepos,
 		})
 	} else if len(purlSpec) > 0 {
 		analytics.TrackCommandScanPurlScan()

--- a/scan.go
+++ b/scan.go
@@ -42,6 +42,7 @@ var (
 	githubRepoUrls                   []string
 	githubOrgUrl                     string
 	githubOrgMaxRepositories         int
+	githubOrgExcludeRepos            string
 	githubSkipDependencyGraphAPI     bool
 	scanExclude                      []string
 	transitiveAnalysis               bool
@@ -134,6 +135,8 @@ func newScanCommand() *cobra.Command {
 		"Github organization URL (Example: https://github.com/safedep)")
 	cmd.Flags().IntVarP(&githubOrgMaxRepositories, "github-org-max-repo", "", 1000,
 		"Maximum number of repositories to process for the Github Org")
+	cmd.Flags().StringVar(&githubOrgExcludeRepos, "github-org-exclude-repos", "", 
+		"Comma-separated list of GitHub repos to exclude during org scan (format: org/repo1,org/repo2)")
 	cmd.Flags().BoolVarP(&githubSkipDependencyGraphAPI, "skip-github-dependency-graph-api", "", false,
 		"Do not use GitHub Dependency Graph API to fetch dependencies")
 	cmd.Flags().StringVarP(&lockfileAs, "lockfile-as", "", "",
@@ -365,6 +368,7 @@ func internalStartScan() error {
 			IncludeArchived:        false,
 			MaxRepositories:        githubOrgMaxRepositories,
 			SkipDependencyGraphAPI: githubSkipDependencyGraphAPI,
+			ExcludeRepos:           githubOrgExcludeRepos,
 		})
 	} else if len(purlSpec) > 0 {
 		analytics.TrackCommandScanPurlScan()

--- a/scan.go
+++ b/scan.go
@@ -42,6 +42,7 @@ var (
 	githubRepoUrls                   []string
 	githubOrgUrl                     string
 	githubOrgMaxRepositories         int
+	githubOrgExcludedRepos           []string
 	githubSkipDependencyGraphAPI     bool
 	scanExclude                      []string
 	transitiveAnalysis               bool
@@ -134,7 +135,7 @@ func newScanCommand() *cobra.Command {
 		"Github organization URL (Example: https://github.com/safedep)")
 	cmd.Flags().IntVarP(&githubOrgMaxRepositories, "github-org-max-repo", "", 1000,
 		"Maximum number of repositories to process for the Github Org")
-	cmd.Flags().StringArrayVarP(&githubOrgExcludeRepos, "github-org-exclude-repos", "", []string{},
+	cmd.Flags().StringArrayVarP(&githubOrgExcludedRepos, "github-org-exclude-repos", "", []string{},
 		"Comma-separated list of GitHub repos to exclude during org scan (format: org/repo1,org/repo2)")
 	cmd.Flags().BoolVarP(&githubSkipDependencyGraphAPI, "skip-github-dependency-graph-api", "", false,
 		"Do not use GitHub Dependency Graph API to fetch dependencies")

--- a/scan.go
+++ b/scan.go
@@ -42,7 +42,7 @@ var (
 	githubRepoUrls                   []string
 	githubOrgUrl                     string
 	githubOrgMaxRepositories         int
-	githubOrgExcludeRepos            string
+	githubOrgExcludeRepos            []string
 	githubSkipDependencyGraphAPI     bool
 	scanExclude                      []string
 	transitiveAnalysis               bool
@@ -135,7 +135,7 @@ func newScanCommand() *cobra.Command {
 		"Github organization URL (Example: https://github.com/safedep)")
 	cmd.Flags().IntVarP(&githubOrgMaxRepositories, "github-org-max-repo", "", 1000,
 		"Maximum number of repositories to process for the Github Org")
-	cmd.Flags().StringVar(&githubOrgExcludeRepos, "github-org-exclude-repos", "", 
+	cmd.Flags().StringArrayVarP(&githubOrgExcludeRepos, "github-org-exclude-repos", "", 
 		"Comma-separated list of GitHub repos to exclude during org scan (format: org/repo1,org/repo2)")
 	cmd.Flags().BoolVarP(&githubSkipDependencyGraphAPI, "skip-github-dependency-graph-api", "", false,
 		"Do not use GitHub Dependency Graph API to fetch dependencies")

--- a/scan.go
+++ b/scan.go
@@ -42,7 +42,6 @@ var (
 	githubRepoUrls                   []string
 	githubOrgUrl                     string
 	githubOrgMaxRepositories         int
-	githubOrgExcludeRepos            []string
 	githubSkipDependencyGraphAPI     bool
 	scanExclude                      []string
 	transitiveAnalysis               bool
@@ -135,7 +134,7 @@ func newScanCommand() *cobra.Command {
 		"Github organization URL (Example: https://github.com/safedep)")
 	cmd.Flags().IntVarP(&githubOrgMaxRepositories, "github-org-max-repo", "", 1000,
 		"Maximum number of repositories to process for the Github Org")
-	cmd.Flags().StringArrayVarP(&githubOrgExcludeRepos, "github-org-exclude-repos", "", 
+	cmd.Flags().StringArrayVarP(&githubOrgExcludeRepos, "github-org-exclude-repos", "", []string{},
 		"Comma-separated list of GitHub repos to exclude during org scan (format: org/repo1,org/repo2)")
 	cmd.Flags().BoolVarP(&githubSkipDependencyGraphAPI, "skip-github-dependency-graph-api", "", false,
 		"Do not use GitHub Dependency Graph API to fetch dependencies")
@@ -368,7 +367,6 @@ func internalStartScan() error {
 			IncludeArchived:        false,
 			MaxRepositories:        githubOrgMaxRepositories,
 			SkipDependencyGraphAPI: githubSkipDependencyGraphAPI,
-			ExcludeRepos:           githubOrgExcludeRepos,
 		})
 	} else if len(purlSpec) > 0 {
 		analytics.TrackCommandScanPurlScan()


### PR DESCRIPTION
## Note

The aim is to exclude specific repos like _**your-org/repo1**_ from being scanned when running, for example:
```
vet scan --github-org=https://github.com/your-org \
         --github-org-exclude-repos="your-org/repo1,your-org/repo2"
```

## Changes
- Added ExcludeRepos field to **_GithubOrgReaderConfig_**
- Registered **_--github-org-exclude-repos_** in scan.go
- Implemented _**isExcludedRepo()**_ helper
- Modified _**handleRepositoryBatch()**_ to skip excluded repos based on repo.GetFullName()