### PR TITLE
fix(tools): prevent nil pointer panic in GetPackageLicenseInfo handler

### DIFF
--- a/mcp/tools/package_insights.go
+++ b/mcp/tools/package_insights.go
@@ -129,6 +129,10 @@ func (t *packageInsightsTool) executeGetPackageLicenseInfo(ctx context.Context,
 		return nil, fmt.Errorf("failed to get package license info: %w", err)
 	}
 
+	if licenseInfo == nil {
+		return nil, fmt.Errorf("no license info returned for package: %s", purl)
+	}
+
 	logger.Debugf("Found %d license info for package: %s", len(licenseInfo.Licenses), purl)
 
 	licenseInfoJson, err := serializeForLlm(licenseInfo)

--- a/mcp/tools/package_insights_test.go
+++ b/mcp/tools/package_insights_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	vulnerabilityv1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/vulnerability/v1"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/safedep/vet/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -293,6 +293,19 @@ func TestPackageInsightsTool_ExecuteGetPackageLicenseInfo(t *testing.T) {
 			},
 			expectedContains: "",
 			expectedError:    "failed to get package license info",
+		},
+
+		{
+			name: "driver returns nil license info",
+			requestArgs: map[string]interface{}{
+				"purl": "pkg:npm/express@4.17.1",
+			},
+			setupDriver: func(driver *MockDriver) {
+				driver.On("GetPackageVersionLicenseInfo", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
+					Return(nil, nil)
+			},
+			expectedContains: "",
+			expectedError:    "no license info returned for package",
 		},
 	}
 


### PR DESCRIPTION
Fixes: #544


This commit adds a nil check in the GetPackageLicenseInfo handler to avoid potential panics when license information is unavailable.
It ensures the handler gracefully returns an empty result or appropriate error instead of crashing the application