### PR TITLE
add support for extensions purl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/posthog/posthog-go v1.5.11
 	github.com/safedep/code v0.0.0-20250619080228-57f5b7b5e58c
-	github.com/safedep/dry v0.0.0-20250618113059-9f8b677e299c
+	github.com/safedep/dry v0.0.0-20250716064316-9afa8962ced6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/spdx/tools-golang v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -1248,6 +1248,8 @@ github.com/safedep/code v0.0.0-20250619080228-57f5b7b5e58c h1:ao6OCJyNomRFgpRtVb
 github.com/safedep/code v0.0.0-20250619080228-57f5b7b5e58c/go.mod h1:5gnHWxq6kbun+r3qf52UHD5f9bd36sWhkDLXvPRd4ZA=
 github.com/safedep/dry v0.0.0-20250618113059-9f8b677e299c h1:xr6P3xzQqxPx93qbH/LPjyK46oEEA6N0nYyiQSjikkI=
 github.com/safedep/dry v0.0.0-20250618113059-9f8b677e299c/go.mod h1:8GbUOzdf46FT4j5h9lw9DdA3wM9NgIVEZjTfkzNe+Cw=
+github.com/safedep/dry v0.0.0-20250716064316-9afa8962ced6 h1:1RY9Q9ObuziUfzfN/Ov2JVNR8o4CljNemilRVSoSN8w=
+github.com/safedep/dry v0.0.0-20250716064316-9afa8962ced6/go.mod h1:JYHgU3vlgDE14Sb7NjytF+clPr+3jGCoS1HIkHn2xLE=
 github.com/saferwall/pe v1.5.6 h1:DrRLnoQFxHWJ5lJUmrH7X2L0xeUu6SUS95Dc61eW2Yc=
 github.com/saferwall/pe v1.5.6/go.mod h1:mJx+PuptmNpoPFBNhWs/uDMFL/kTHVZIkg0d4OUJFbQ=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=

--- a/pkg/common/purl/purl.go
+++ b/pkg/common/purl/purl.go
@@ -77,6 +77,10 @@ func PurlTypeToEcosystem(purlType string) (lockfile.Ecosystem, error) {
 		"rubygems":              lockfile.BundlerEcosystem,
 		packageurl.TypeGithub:   models.EcosystemGitHubActions,
 		"actions":               models.EcosystemGitHubActions,
+		"vscode":                models.EcosystemVSCodeExtensions,
+		"vsx":                   models.EcosystemVSCodeExtensions,
+		"vsix":                  models.EcosystemVSCodeExtensions,
+		"openvsx":               models.EcosystemOpenVSXExtensions,
 	}
 
 	ecosystem, ok := knownTypes[purlType]

--- a/pkg/common/purl/purl_test.go
+++ b/pkg/common/purl/purl_test.go
@@ -50,6 +50,46 @@ func TestParsePackageUrl(t *testing.T) {
 			"v2",
 			nil,
 		},
+		{
+			"Parse vscode Extensions PURL",
+			"pkg:vscode/streetsidesoftware.code-spell-checker@4.0.47",
+			models.EcosystemVSCodeExtensions,
+			"streetsidesoftware.code-spell-checker",
+			"4.0.47",
+			nil,
+		},
+		{
+			"Parse vsix Extensions PURL",
+			"pkg:vsix/streetsidesoftware.code-spell-checker@4.0.47",
+			models.EcosystemVSCodeExtensions,
+			"streetsidesoftware.code-spell-checker",
+			"4.0.47",
+			nil,
+		},
+		{
+			"Parse vsx Extensions PURL",
+			"pkg:vsx/streetsidesoftware.code-spell-checker@4.0.47",
+			models.EcosystemVSCodeExtensions,
+			"streetsidesoftware.code-spell-checker",
+			"4.0.47",
+			nil,
+		},
+		{
+			"Parse openvsx Extensions PURL",
+			"pkg:openvsx/streetsidesoftware.code-spell-checker@4.0.47",
+			models.EcosystemOpenVSXExtensions,
+			"streetsidesoftware.code-spell-checker",
+			"4.0.47",
+			nil,
+		},
+		{
+			"Parse openvsx Extensions PURL with empty verison",
+			"pkg:openvsx/streetsidesoftware.code-spell-checker",
+			models.EcosystemOpenVSXExtensions,
+			"streetsidesoftware.code-spell-checker",
+			"",
+			nil,
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
Add supports for 
- `openvsx` in inspect cmd: `vet inspect malware --purl pkg:/openvsx/streetsidesoftware.code-spell-checker@4.0.47`
- scanning VS Code & OpenVSX extensions through `vet scan`: `vet scan --purl pkg:/vscode/streetsidesoftware.code-spell-checker@4.0.47`
