### PR TITLE
fix/dir reader log path failure

### DIFF
--- a/pkg/readers/dir_reader.go
+++ b/pkg/readers/dir_reader.go
@@ -59,7 +59,8 @@ func (p *directoryReader) EnumManifests(handler func(*models.PackageManifest,
 ) error {
 	err := filepath.WalkDir(p.config.Path, func(path string, info os.DirEntry, err error) error {
 		if err != nil {
-			return err
+			logger.Warnf("Failed to access path %s due to %v", path, err)
+			return nil
 		}
 
 		if info.IsDir() && p.ignorableDirectory(info.Name()) {

--- a/pkg/readers/dir_reader.go
+++ b/pkg/readers/dir_reader.go
@@ -57,7 +57,15 @@ func (p *directoryReader) ApplicationName() (string, error) {
 func (p *directoryReader) EnumManifests(handler func(*models.PackageManifest,
 	PackageReader) error,
 ) error {
+	// Fail if the root path does not exist
+	if _, err := os.Stat(p.config.Path); err != nil {
+		return err
+	}
+
 	err := filepath.WalkDir(p.config.Path, func(path string, info os.DirEntry, err error) error {
+		// We don't fail the entire walk if we cannot access a path
+		// This is required when we are scanning a file system and some directories such as .Trash
+		// are not accessible
 		if err != nil {
 			logger.Warnf("Failed to access path %s due to %v", path, err)
 			return nil


### PR DESCRIPTION
- **fix: Avoid hard failure in dir scanner on path errors**
- **fix: Ensure dir reader fails if root path doesn't exist**
