### PR TITLE
feat: show manifest relative path in summary report

### DIFF
--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -572,7 +572,7 @@ func (r *summaryReporter) addRemediationAdviceTableRows(tbl table.Writer,
 
 	currentWorkingDirectory, err := os.Getwd()
 	if err != nil {
-		log.Warnf(WarningText(fmt.Sprintf("Error getting current working directory: %s", err.Error())))
+		log.Warnf("Error getting current working directory: %s", err.Error())
 		currentWorkingDirectory = ""
 	}
 
@@ -645,11 +645,10 @@ func (r *summaryReporter) addRemediationAdviceTableRows(tbl table.Writer,
 			}
 		}
 
-		manifestPath, err := r.packageManifestRelativePath(sp.pkg, currentWorkingDirectory)
-		// If failed to get relative path, fallback to absolute path
+		manifestPath, err := r.packageManifestRelativePath(currentWorkingDirectory, sp.pkg.Manifest.Path)
 		if err != nil {
-			log.Warnf(WarningText(fmt.Sprintf("Error getting manifest relative path: %s", err.Error())))
-			manifestPath = sp.pkg.Manifest.Path
+			log.Warnf("Error getting manifest relative path: %s", err.Error())
+			manifestPath = sp.pkg.Manifest.GetDisplayPath()
 		}
 
 		// Add Manifest Path information just below package name
@@ -691,10 +690,8 @@ func (r *summaryReporter) packageVulnerabilityRiskText(pkg *models.Package) stri
 	return WhiteBgText(" Unknown ")
 }
 
-func (r *summaryReporter) packageManifestRelativePath(pkg *models.Package, currentWorkingDirectory string) (string, error) {
-	fullPath := pkg.Manifest.Path
-
-	relPath, err := filepath.Rel(currentWorkingDirectory, fullPath)
+func (r *summaryReporter) packageManifestRelativePath(currentWorkingDirectory, manifestFullPath string) (string, error) {
+	relPath, err := filepath.Rel(currentWorkingDirectory, manifestFullPath)
 	if err != nil {
 		return "", fmt.Errorf("error getting relative path: %w", err)
 	}

--- a/pkg/reporter/summary_test.go
+++ b/pkg/reporter/summary_test.go
@@ -3,7 +3,6 @@ package reporter
 import (
 	"testing"
 
-	"github.com/safedep/vet/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,42 +10,32 @@ func TestManifestRelativePath(t *testing.T) {
 	testCases := []struct {
 		name string
 
-		pkg               *models.Package
 		currentWorkingDir string
+		manifestFullPath  string
 
 		expectError          bool
 		expectedRelativePath string
 	}{
 		{
-			name: "valid current working directory",
-			pkg: &models.Package{
-				Manifest: &models.PackageManifest{
-					Path: "/home/user/work/company/project/source/package-lock.json",
-				},
-			},
-			currentWorkingDir:    "/home/user/work/company/project/source",
+			name:              "valid current working directory",
+			currentWorkingDir: "/home/user/work/company/project/source",
+			manifestFullPath:  "/home/user/work/company/project/source/package-lock.json",
+
 			expectError:          false,
 			expectedRelativePath: "package-lock.json",
 		},
 		{
-			name: "valid current working directory with sub dir manifest path",
-			pkg: &models.Package{
-				Manifest: &models.PackageManifest{
-					Path: "/home/user/work/company/project/source/apps/cli/go.mod",
-				},
-			},
-			currentWorkingDir:    "/home/user/work/company/project/source",
+			name:              "valid current working directory with sub dir manifest path",
+			currentWorkingDir: "/home/user/work/company/project/source",
+			manifestFullPath:  "/home/user/work/company/project/source/apps/cli/go.mod",
+
 			expectError:          false,
 			expectedRelativePath: "apps/cli/go.mod",
 		},
 		{
-			name: "empty current working directory - error on os.Getwd()",
-			pkg: &models.Package{
-				Manifest: &models.PackageManifest{
-					Path: "/home/user/work/company/project/source/package-lock.json",
-				},
-			},
+			name:              "empty current working directory - error on os.Getwd()",
 			currentWorkingDir: "", // os.Getwd() failed, then currentWorkingDir = ""
+			manifestFullPath:  "/home/user/work/company/project/source/package-lock.json",
 			expectError:       true,
 		},
 	}
@@ -56,7 +45,7 @@ func TestManifestRelativePath(t *testing.T) {
 			t.Parallel()
 
 			r := &summaryReporter{}
-			relativePath, err := r.packageManifestRelativePath(test.pkg, test.currentWorkingDir)
+			relativePath, err := r.packageManifestRelativePath(test.currentWorkingDir, test.manifestFullPath)
 
 			if test.expectError {
 				assert.Error(t, err)


### PR DESCRIPTION
fixes #503 

<img width="989" height="569" alt="image" src="https://github.com/user-attachments/assets/c3941c32-f33b-4b3d-9580-f8fee34d9f11" />

