### PR TITLE
fix: github action versions not pinned and top level permissions missing

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: latest
           args: --issues-exit-code=1 --timeout=10m

--- a/.github/workflows/vet-container-scanning-e2e.yml
+++ b/.github/workflows/vet-container-scanning-e2e.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions: read-all
+
 jobs:
   e2e-scan:
     name: E2E Scan on ${{ matrix.os }}
@@ -15,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
fixes: https://github.com/safedep/vet/security/code-scanning/73
fixes: https://github.com/safedep/vet/security/code-scanning/69

