### PR TITLE
fix: wrong working directory construction in mcp publishing CI

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -78,7 +78,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: .mcp-publisher
+        working-directory: ./.mcp-publisher
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
```txt
Error: An error occurred trying to start process 
'/usr/bin/bash' with working directory 
'/home/runner/work/vet/vet/.mcp-publisher'. No such file or 
directory
```

the `.mcp-publisher` is prefixed with `vet` which should not be. 