### PR TITLE
fix: OCI packages must not have 'version' field

### DIFF
--- a/.mcp-publisher/server.json
+++ b/.mcp-publisher/server.json
@@ -33,7 +33,6 @@
     {
       "registryType": "oci",
       "identifier": "ghcr.io/safedep/vet:VERSION_FROM_ENV",
-      "version": "VERSION_FROM_ENV",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {


### PR DESCRIPTION
https://github.com/safedep/vet/actions/runs/19701505947/job/56439644925