### PR TITLE
docs: Add Codex CLI MCP server configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,28 +261,6 @@ vet version
 - **[Query Mode](https://docs.safedep.io/cloud/quickstart#query-your-data)** - Scan once, analyze multiple times
 - **[GitHub Integration](https://docs.safedep.io/)** - Repository and organization scanning
 
-### Codex CLI Integration
-
-Use `vet` as an MCP server in [Codex CLI](https://github.com/openai/codex). Add the following to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.vet-mcp]
-command = "docker"
-args = [
-  "run",
-  "--rm",
-  "-i",
-  "ghcr.io/safedep/vet:latest",
-  "-l",
-  "/tmp/vet-mcp.log",
-  "server",
-  "mcp"
-]
-startup_timeout_sec = 30
-```
-
-This enables Codex CLI to automatically vet packages during AI-assisted development, protecting against malicious packages and vulnerabilities.
-
 ## 📊 Privacy
 
 `vet` collects anonymous usage telemetry to improve the product. **Your code and package information is never transmitted.**


### PR DESCRIPTION
## Summary

This PR adds documentation for configuring vet as an MCP server in Codex CLI.

## Changes

- Added Codex CLI integration section to README.md under Advanced Features
- Added Codex CLI configuration example to docs/mcp.md
- Included TOML configuration for ~/.codex/config.toml with proper startup timeout

## Configuration Example

```toml
[mcp_servers.vet-mcp]
command = "docker"
args = [
  "run",
  "--rm",
  "-i",
  "ghcr.io/safedep/vet:latest",
  "-l",
  "/tmp/vet-mcp.log",
  "server",
  "mcp"
]
startup_timeout_sec = 30
```


<img width="3024" height="574" alt="image" src="https://github.com/user-attachments/assets/406045a0-da28-4333-9c11-d401263f40d2" />



This enables Codex CLI users to automatically vet packages during AI-assisted development, protecting against malicious packages and vulnerabilities.