### PR TITLE
Bug: remove early scan stop

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -110,11 +110,6 @@ func (s *packageManifestScanner) startManifestScanner(ctx context.Context,
 			break
 		}
 
-		// Stop scan if there is a pending error
-		if s.hasError() {
-			break
-		}
-
 		manifest, ok := <-incoming
 		if !ok {
 			break


### PR DESCRIPTION
## Issue
When running `vet scan` in a directory containing both `package.json` and `requirements.txt`, the packages listed in `requirements.txt` were ignored when using `--fail-fast` and `--filter-fail` flags together. This led to incomplete security scans, as Python dependencies were not analyzed.

## Approach
The scanner's manifest processing loop in pkg/scanner/scanner.go checked for fail-fast errors between processing each manifest. When a filter match occurred in the first manifest, such as the package.json. The analyzer would raise an ET_AnalyzerFailOnError event, which set the failOnError flag. On the next iteration of the manifest processing loop, the scanner would check if s.hasError() and break, stopping before processing remaining manifests like requirements.txt.

We can proceed by removing the if s.hasError() check. The fail-fast error will be handled at the end of the scan in Start() method.

Closes #670 