### PR TITLE
fix(readers): support windows-style exclude patterns

### DIFF
--- a/pkg/readers/common.go
+++ b/pkg/readers/common.go
@@ -2,6 +2,7 @@ package readers
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -14,6 +15,10 @@ type exclusionMatcher struct {
 	Exclusions []string
 }
 
+func normalizeGlobCandidate(value string) string {
+	return strings.ReplaceAll(value, "\\", "/")
+}
+
 func newPathExclusionMatcher(exclusions []string) *exclusionMatcher {
 	return &exclusionMatcher{
 		Exclusions: exclusions,
@@ -21,16 +26,20 @@ func newPathExclusionMatcher(exclusions []string) *exclusionMatcher {
 }
 
 func (ex *exclusionMatcher) Match(term string) bool {
+	normalizedTerm := normalizeGlobCandidate(term)
+
 	for _, exclusionPattern := range ex.Exclusions {
+		normalizedPattern := normalizeGlobCandidate(exclusionPattern)
+
 		// Try matching in current form first
-		if m, err := doublestar.Match(exclusionPattern, term); err == nil && m {
+		if m, err := doublestar.Match(normalizedPattern, normalizedTerm); err == nil && m {
 			return true
 		}
 
 		// If term is relative and pattern is absolute, convert term to absolute
 		if !filepath.IsAbs(term) && filepath.IsAbs(exclusionPattern) {
 			if abs, err := filepath.Abs(term); err == nil {
-				if m, err := doublestar.Match(exclusionPattern, abs); err == nil && m {
+				if m, err := doublestar.Match(normalizedPattern, normalizeGlobCandidate(abs)); err == nil && m {
 					return true
 				}
 			}
@@ -39,7 +48,7 @@ func (ex *exclusionMatcher) Match(term string) bool {
 		// If term is absolute and pattern is relative, convert pattern to absolute
 		if filepath.IsAbs(term) && !filepath.IsAbs(exclusionPattern) {
 			if abs, err := filepath.Abs(exclusionPattern); err == nil {
-				if m, err := doublestar.Match(abs, term); err == nil && m {
+				if m, err := doublestar.Match(normalizeGlobCandidate(abs), normalizedTerm); err == nil && m {
 					return true
 				}
 			}

--- a/pkg/readers/common_test.go
+++ b/pkg/readers/common_test.go
@@ -1,6 +1,7 @@
 package readers
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,4 +117,19 @@ func TestExcludedPath(t *testing.T) {
 				tc.shouldBeExcluded, tc.path, tc.patterns)
 		})
 	}
+}
+
+func TestExcludedPathWindowsStylePatternAgainstAbsolutePath(t *testing.T) {
+	absPath, err := filepath.Abs(filepath.Join("pkg", "readers"))
+	assert.NoError(t, err)
+
+	matcher := newPathExclusionMatcher([]string{`pkg\*`})
+	assert.True(t, matcher.Match(absPath))
+}
+
+func TestExcludedPathWindowsStyleSeparators(t *testing.T) {
+	matcher := newPathExclusionMatcher([]string{`pkg\readers\**`})
+
+	assert.True(t, matcher.Match(`pkg\readers\fixtures\requirements.txt`))
+	assert.False(t, matcher.Match(`cmd\vet\main.go`))
 }


### PR DESCRIPTION
Fixes #628

## Summary
- normalize path separators (`\\` and `/`) before applying exclusion glob matching
- keep absolute/relative matching behavior while normalizing both pattern and term
- add tests for Windows-style exclude patterns, including matching against absolute paths

## Why
`--exclude 'pkg\\*'` did not behave correctly on Windows because matching logic mixed path separators.

## Notes
- commit is signed off (`-s`) as required by `CONTRIBUTING.md`
- local `go test ./pkg/readers` was blocked in this environment by an external file-lock on Go module cache; no code-level test failure was observed