### PR TITLE
fix(reporter): suppress --report-markdown hint when markdown report is already enabled

### DIFF
--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -75,6 +75,10 @@ type SummaryReporterConfig struct {
 	// This requires code analysis to be enabled with dependency
 	// usage evidences to be available
 	ShowOnlyPackagesWithEvidence bool
+
+	// MarkdownReportEnabled indicates that a markdown report is already being
+	// generated, so the hint to use --report-markdown should be suppressed.
+	MarkdownReportEnabled bool
 }
 
 type summaryReporter struct {
@@ -553,7 +557,9 @@ func (r *summaryReporter) renderRemediationAdvice() {
 				len(sortedPackages)-summaryReportMaxUpgradeAdvice),
 		))
 
-		fmt.Println(BoldText("Run vet with `--report-markdown=/path/to/report.md` for details"))
+		if !r.config.MarkdownReportEnabled {
+			fmt.Println(BoldText("Run vet with `--report-markdown=/path/to/report.md` for details"))
+		}
 	}
 }
 

--- a/query.go
+++ b/query.go
@@ -244,6 +244,7 @@ func internalStartQuery() error {
 			MaxAdvice:                    querySummaryReportMaxAdvice,
 			GroupByDirectDependency:      querySummaryReportGroupByDirectDeps,
 			ShowOnlyPackagesWithEvidence: querySummaryUsedOnly,
+			MarkdownReportEnabled:        !utils.IsEmptyString(queryMarkdownReportPath),
 		})
 		if err != nil {
 			return err

--- a/scan.go
+++ b/scan.go
@@ -632,6 +632,7 @@ func internalStartScan() error {
 			MaxAdvice:                    summaryReportMaxAdvice,
 			GroupByDirectDependency:      summaryReportGroupByDirectDeps,
 			ShowOnlyPackagesWithEvidence: summaryReportUsedOnly,
+			MarkdownReportEnabled:        !utils.IsEmptyString(markdownReportPath),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

The hint at `pkg/reporter/summary.go:556` unconditionally prints `Run vet with --report-markdown=...` even when the user has already passed `--report-markdown`. This adds a `MarkdownReportEnabled` field to `SummaryReporterConfig` and gates the println on it so the hint is shown only when markdown output is **not** enabled. `scan` and `query` subcommands both pass the flag state through.

Fixes #725.

## Change

- `pkg/reporter/summary.go`: Add `MarkdownReportEnabled bool` field with a godoc comment, wrap the existing `fmt.Println` hint in an `if !r.config.MarkdownReportEnabled` guard.
- `scan.go`: pass `MarkdownReportEnabled: !utils.IsEmptyString(markdownReportPath)` when constructing the `SummaryReporterConfig`.
- `query.go`: same as above.

The new field is a `bool` whose zero value is `false`, preserving backward-compatible behavior for any existing `SummaryReporterConfig{}` literal (only `pkg/reporter/markdown.go:66` has another instantiation, and its nested summary never calls `Finish()` — confirmed by tracing).

The mirror predicate `!utils.IsEmptyString(markdownReportPath)` is the same one used at `scan.go:644` and `query.go:256` to decide whether to instantiate the markdown reporter at all.

---

Prepared with AI assistance (Claude Sonnet 4.6 via Claude Code).