### PR TITLE
fix: use PowerShell Expand-Archive on Windows for npm install

### DIFF
--- a/publish/npm/install.js
+++ b/publish/npm/install.js
@@ -109,7 +109,16 @@ function extractArchive(archivePath, extractDir) {
   const isZip = archivePath.endsWith(".zip");
 
   if (isZip) {
-    execSync(`unzip -o "${archivePath}" -d "${extractDir}"`, { stdio: "pipe" });
+    if (process.platform === "win32") {
+      execSync(
+        `powershell -NoProfile -Command "Expand-Archive -Force -Path '${archivePath}' -DestinationPath '${extractDir}'"`,
+        { stdio: "pipe" },
+      );
+    } else {
+      execSync(`unzip -o "${archivePath}" -d "${extractDir}"`, {
+        stdio: "pipe",
+      });
+    }
   } else {
     execSync(`tar -xzf "${archivePath}" -C "${extractDir}"`, { stdio: "pipe" });
   }


### PR DESCRIPTION
Windows does not have unzip by default, causing npm install to fail. Uses PowerShell Expand-Archive on win32, same fix as https://github.com/safedep/pmg/pull/190.


<img width="1485" height="247" alt="image" src="https://github.com/user-attachments/assets/ca11985f-a0b0-4ee1-a779-6f5c709e3a26" />
