### PR TITLE
Honor registry default package versions in insights

### DIFF
--- a/pkg/scanner/enrich_insightsv2.go
+++ b/pkg/scanner/enrich_insightsv2.go
@@ -185,21 +185,7 @@ func (e *insightsBasedPackageEnricherV2) convertInsightsV2ToV1(pvi *packagev1.Pa
 	// Package Version
 	// Why do we need this inside insights?
 
-	// Current Version
-	// We will pick the latest version from available versions.
-	// This will work for most cases but not for all.
-	currentVersion := ""
-	for _, v := range pvi.GetAvailableVersions() {
-		if currentVersion == "" {
-			currentVersion = v.GetVersion()
-			continue
-		}
-
-		if semver.IsAhead(currentVersion, v.GetVersion()) {
-			currentVersion = v.GetVersion()
-		}
-	}
-
+	currentVersion := currentVersionFromAvailableVersions(pvi.GetAvailableVersions())
 	insights.PackageCurrentVersion = &currentVersion
 
 	// Projects
@@ -350,6 +336,26 @@ func (e *insightsBasedPackageEnricherV2) convertInsightsV2ToV1(pvi *packagev1.Pa
 
 func (e *insightsBasedPackageEnricherV2) Wait() error {
 	return nil
+}
+
+func currentVersionFromAvailableVersions(versions []*packagev1.PackageAvailableVersion) string {
+	currentVersion := ""
+	for _, v := range versions {
+		version := v.GetVersion()
+		if version == "" {
+			continue
+		}
+
+		if v.GetDefaultVersion() {
+			return version
+		}
+
+		if currentVersion == "" || semver.IsAhead(currentVersion, version) {
+			currentVersion = version
+		}
+	}
+
+	return currentVersion
 }
 
 // Should this be in models?

--- a/pkg/scanner/enrich_insightsv2_test.go
+++ b/pkg/scanner/enrich_insightsv2_test.go
@@ -1,0 +1,39 @@
+package scanner
+
+import (
+	"testing"
+
+	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentVersionFromAvailableVersions(t *testing.T) {
+	t.Run("prefers registry default version", func(t *testing.T) {
+		versions := []*packagev1.PackageAvailableVersion{
+			{Version: "v1.0.2"},
+			{Version: "v6.0.0-rc.1"},
+			{Version: "v5.2.2", DefaultVersion: true},
+		}
+
+		assert.Equal(t, "v5.2.2", currentVersionFromAvailableVersions(versions))
+	})
+
+	t.Run("falls back to highest semver version", func(t *testing.T) {
+		versions := []*packagev1.PackageAvailableVersion{
+			{Version: "v1.0.2"},
+			{Version: "v5.2.2"},
+			{Version: "v4.5.2"},
+		}
+
+		assert.Equal(t, "v5.2.2", currentVersionFromAvailableVersions(versions))
+	})
+
+	t.Run("skips empty versions", func(t *testing.T) {
+		versions := []*packagev1.PackageAvailableVersion{
+			{Version: ""},
+			{Version: "v1.0.2"},
+		}
+
+		assert.Equal(t, "v1.0.2", currentVersionFromAvailableVersions(versions))
+	})
+}


### PR DESCRIPTION
Closes #514.

## Summary
- Prefer the Insights V2 `default_version` marker when mapping available versions into the legacy `PackageCurrentVersion` field.
- Keep the existing semver ordering as a fallback when no registry default is provided.
- Add coverage for default-version selection and fallback behavior.

## Tests
- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./pkg/scanner ./pkg/common/registry -count=1`
- `env -u NO_COLOR TERM=xterm-256color GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./...`