### PR TITLE
docs: add contributors list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,14 @@ vet stands on the shoulders of giants:
 
 [OSV](https://osv.dev) • [OpenSSF Scorecard](https://securityscorecards.dev/) • [SLSA](https://slsa.dev/) • [OSV-SCALIBR](https://github.com/google/osv-scalibr) • [Syft](https://github.com/anchore/syft)
 
+### Contributors
+
+Thank you to all contributors ❤️
+
+<a href="https://github.com/safedep/vet/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=safedep/vet" alt="Contributors to vet" />
+</a>
+
 ---
 
 <p><strong>Secure your supply chain today. Star the repo and get started!</strong></p>


### PR DESCRIPTION
## Summary

Adds a **Contributors** section to `README.md`, mirroring the approach already used in the [`safedep/pmg`](https://github.com/safedep/pmg) repository. It uses [contrib.rocks](https://contrib.rocks) to render a visual grid of contributors that links to the repo's contributors graph.

## Changes

- Added a `### Contributors` section near the footer (after "Built With Open Source") with a `contrib.rocks` image pointing at `safedep/vet`.

```html
### Contributors

Thank you to all contributors ❤️

<a href="https://github.com/safedep/vet/graphs/contributors">
  `&lt;img src="https://contrib.rocks/image?repo=safedep/vet" alt="Contributors to vet" /&gt;`
</a>
```

## Reference

This matches the contributors block in `pmg/README.md`:

```html
<a href="https://github.com/safedep/pmg/graphs/contributors">
  `&lt;img src="https://contrib.rocks/image?repo=safedep/pmg" alt="Contributors to PMG" /&gt;`
</a>
```

https://claude.ai/code/session_019pX4HwkALUNBgt4HRLVG5i

---
_Generated by [Claude Code](https://claude.ai/code/session_019pX4HwkALUNBgt4HRLVG5i)_