### PR TITLE
feat: ide extension scanning support for vet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,14 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Build and Test
         run: |
           go mod tidy
           go build
-          go test -coverprofile=coverage.txt -v ./...
+          gotestsum --format github-actions -- -coverprofile=coverage.txt ./...
         env:
           VET_E2E: true
 

--- a/cmd/endpoint/scan.go
+++ b/cmd/endpoint/scan.go
@@ -128,7 +128,7 @@ local table and exits 0 with a hint.`,
 	return cmd
 }
 
-func runScan(ctx context.Context, opts Options) error {
+var runScan scanRunner = func(ctx context.Context, opts Options) error {
 	deps := scanDeps{
 		resolver: auth.NewLayeredResolver(),
 		buildScanners: func(opts Options) ([]inventory.Scanner, error) {

--- a/cmd/endpoint/scan.go
+++ b/cmd/endpoint/scan.go
@@ -63,11 +63,18 @@ type Options struct {
 // It is the integration point for cmd/ai/discover; opts.Kinds is
 // overwritten.
 func RunAITool(ctx context.Context, opts Options) error {
+	return runAIToolWithRunner(ctx, opts, runScan)
+}
+
+// runAIToolWithRunner is the testable core of RunAITool. It pins the ai-tool
+// kinds and delegates to run, allowing tests to intercept without swapping
+// the package-level runScan.
+func runAIToolWithRunner(ctx context.Context, opts Options, run scanRunner) error {
 	opts.Kinds = []string{
 		scanners.KindAITool,
 		scanners.KindAgentSkill,
 	}
-	return runScan(ctx, opts)
+	return run(ctx, opts)
 }
 
 // scanRunner is the function shape captured by the cobra RunE closure;
@@ -128,7 +135,7 @@ local table and exits 0 with a hint.`,
 	return cmd
 }
 
-var runScan scanRunner = func(ctx context.Context, opts Options) error {
+func runScan(ctx context.Context, opts Options) error {
 	deps := scanDeps{
 		resolver: auth.NewLayeredResolver(),
 		buildScanners: func(opts Options) ([]inventory.Scanner, error) {

--- a/cmd/endpoint/scan_test.go
+++ b/cmd/endpoint/scan_test.go
@@ -138,14 +138,10 @@ func captureScanOptions(t *testing.T, args []string) Options {
 // set. IDE extensions belong to endpoint scan only.
 func TestRunAITool_DoesNotIncludeIDEExtensionKind(t *testing.T) {
 	var capturedKinds []string
-	orig := runScan
-	runScan = func(_ context.Context, opts Options) error {
+	_ = runAIToolWithRunner(context.Background(), Options{}, func(_ context.Context, opts Options) error {
 		capturedKinds = opts.Kinds
 		return nil
-	}
-	defer func() { runScan = orig }()
-
-	_ = RunAITool(context.Background(), Options{})
+	})
 
 	assert.NotContains(t, capturedKinds, scanners.KindIDEExtension,
 		"ide-extension must not run under vet ai discover")

--- a/cmd/endpoint/scan_test.go
+++ b/cmd/endpoint/scan_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/safedep/vet/internal/auth"
 	"github.com/safedep/vet/pkg/inventory"
+	"github.com/safedep/vet/pkg/inventory/scanners"
 )
 
 // stubResolver implements auth.Resolver for tests.
@@ -130,6 +131,24 @@ func captureScanOptions(t *testing.T, args []string) Options {
 	cmd.SetErr(&bytes.Buffer{})
 	require.NoError(t, cmd.Execute())
 	return captured
+}
+
+// TestRunAITool_DoesNotIncludeIDEExtensionKind ensures that RunAITool (the
+// entry point for `vet ai discover`) does not pin ide-extension in its kind
+// set. IDE extensions belong to endpoint scan only.
+func TestRunAITool_DoesNotIncludeIDEExtensionKind(t *testing.T) {
+	var capturedKinds []string
+	orig := runScan
+	runScan = func(_ context.Context, opts Options) error {
+		capturedKinds = opts.Kinds
+		return nil
+	}
+	defer func() { runScan = orig }()
+
+	_ = RunAITool(context.Background(), Options{})
+
+	assert.NotContains(t, capturedKinds, scanners.KindIDEExtension,
+		"ide-extension must not run under vet ai discover")
 }
 
 func TestRunScanWithDeps_NoCredentials_BuildsLocalSinkOnly(t *testing.T) {

--- a/pkg/aitool/ai_extension.go
+++ b/pkg/aitool/ai_extension.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 
 	"github.com/safedep/vet/pkg/common/logger"
-	"github.com/safedep/vet/pkg/models"
 	"github.com/safedep/vet/pkg/readers"
 )
 
-// ideNameFromPath extracts the IDE name from an extensions.json path.
-// e.g. "/home/user/.vscode/extensions/extensions.json" → "VS Code"
+// ideDirNames maps the base directory name of an IDE's extensions folder to its
+// display name, e.g. "/home/user/.vscode/extensions/extensions.json" → "VS Code".
 var ideDirNames = map[string]string{
 	".vscode":      "VS Code",
 	".vscode-oss":  "VSCodium",
@@ -27,10 +26,10 @@ const (
 
 type aiExtensionDiscoverer struct {
 	config DiscoveryConfig
+	// reader is injected in tests; nil means use the real default distributions.
+	reader vsixManifestReader
 }
 
-// NewAIExtensionDiscoverer creates a discoverer that bridges the VSIX extension reader
-// to find AI-specific IDE extensions.
 func NewAIExtensionDiscoverer(config DiscoveryConfig) (AIToolReader, error) {
 	return &aiExtensionDiscoverer{config: config}, nil
 }
@@ -39,52 +38,28 @@ func (d *aiExtensionDiscoverer) Name() string { return "AI IDE Extensions" }
 func (d *aiExtensionDiscoverer) App() string  { return ideExtensionsApp }
 
 func (d *aiExtensionDiscoverer) EnumTools(_ context.Context, handler AIToolHandlerFn) error {
-	// IDE extensions are system-scoped; skip when system scope is not enabled
 	if !d.config.ScopeEnabled(AIToolScopeSystem) {
 		return nil
 	}
 
-	vsixReader, err := readers.NewVSIXExtReaderFromDefaultDistributions()
-	if err != nil {
-		logger.Debugf("No IDE extensions found: %v", err)
-		return nil
+	r := d.reader
+	if r == nil {
+		var err error
+		r, err = readers.NewVSIXExtReaderFromDefaultDistributions()
+		if err != nil {
+			logger.Debugf("No IDE extensions found: %v", err)
+			return nil
+		}
 	}
 
-	return vsixReader.EnumManifests(func(manifest *models.PackageManifest, pr readers.PackageReader) error {
-		return pr.EnumPackages(func(pkg *models.Package) error {
-			info, ok := knownAIExtensions[strings.ToLower(pkg.Name)]
-			if !ok {
-				return nil
-			}
-
-			tool := &AITool{
-				Name:       info.DisplayName,
-				Type:       AIToolTypeAIExtension,
-				Scope:      AIToolScopeSystem,
-				App:        ideExtensionsApp,
-				AppDisplay: ideExtensionsAppDisplay,
-				ConfigPath: manifest.GetPath(),
-			}
-
-			tool.ID = generateID(tool.App, string(tool.Type), string(tool.Scope), pkg.Name, tool.ConfigPath)
-			tool.SourceID = generateSourceID(tool.App, tool.ConfigPath)
-			tool.SetMeta("extension.id", pkg.Name)
-			tool.SetMeta("extension.version", pkg.Version)
-			tool.SetMeta("extension.ecosystem", manifest.Ecosystem)
-
-			if ide := ideNameFromPath(manifest.GetPath()); ide != "" {
-				tool.SetMeta("extension.ide", ide)
-				tool.AppDisplay = ide
-			}
-
-			return handler(tool)
-		})
-	})
+	return enumVSIXExtensions(r, ideExtensionsApp, AIToolTypeAIExtension,
+		func(id string) (string, bool) {
+			info, ok := knownAIExtensions[strings.ToLower(id)]
+			return info.DisplayName, ok
+		}, handler)
 }
 
 func ideNameFromPath(configPath string) string {
-	// Walk up from extensions.json to find the IDE directory.
-	// Path pattern: ~/.vscode/extensions/extensions.json
 	dir := filepath.Dir(configPath) // .../extensions
 	dir = filepath.Dir(dir)         // .../.vscode
 	base := filepath.Base(dir)

--- a/pkg/aitool/ai_extension.go
+++ b/pkg/aitool/ai_extension.go
@@ -3,21 +3,10 @@ package aitool
 import (
 	"context"
 	"path/filepath"
-	"strings"
 
 	"github.com/safedep/vet/pkg/common/logger"
 	"github.com/safedep/vet/pkg/readers"
 )
-
-// ideDirNames maps the base directory name of an IDE's extensions folder to its
-// display name, e.g. "/home/user/.vscode/extensions/extensions.json" → "VS Code".
-var ideDirNames = map[string]string{
-	".vscode":      "VS Code",
-	".vscode-oss":  "VSCodium",
-	".cursor":      "Cursor",
-	".windsurf":    "Windsurf",
-	".antigravity": "Antigravity",
-}
 
 const (
 	ideExtensionsApp        = "ide_extensions"
@@ -54,19 +43,13 @@ func (d *aiExtensionDiscoverer) EnumTools(_ context.Context, handler AIToolHandl
 
 	return enumVSIXExtensions(r, ideExtensionsApp, AIToolTypeAIExtension,
 		func(id string) (string, bool) {
-			info, ok := knownAIExtensions[strings.ToLower(id)]
+			info, ok := knownAIExtensions[id]
 			return info.DisplayName, ok
 		}, handler)
 }
 
 func ideNameFromPath(configPath string) string {
-	dir := filepath.Dir(configPath) // .../extensions
-	dir = filepath.Dir(dir)         // .../.vscode
-	base := filepath.Base(dir)
-
-	if name, ok := ideDirNames[base]; ok {
-		return name
-	}
-
-	return ""
+	extDir := filepath.Dir(configPath)               // .../extensions
+	editorDir := filepath.Base(filepath.Dir(extDir)) // .vscode
+	return readers.EditorDisplayName(editorDir)
 }

--- a/pkg/aitool/fixtures/.gitignore
+++ b/pkg/aitool/fixtures/.gitignore
@@ -1,0 +1,6 @@
+# Editor config dirs are globally ignored; allow them here so test fixtures
+# that mirror real IDE layouts (e.g. fixtures/ide_extension/.vscode/) are tracked.
+!.vscode/
+!.cursor/
+!.windsurf/
+!.antigravity/

--- a/pkg/aitool/fixtures/ide_extension/.vscode/extensions/extensions.json
+++ b/pkg/aitool/fixtures/ide_extension/.vscode/extensions/extensions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "identifier": {
+      "id": "ms-python.python",
+      "uuid": "f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a3"
+    },
+    "version": "2023.20.0",
+    "location": {
+      "path": "/home/user/.vscode/extensions/ms-python.python-2023.20.0",
+      "scheme": "file"
+    },
+    "relativeLocation": "ms-python.python-2023.20.0"
+  },
+  {
+    "identifier": {
+      "id": "github.copilot",
+      "uuid": "23c4aeee-f844-43cd-b53e-1113e483f1a6"
+    },
+    "version": "1.200.0",
+    "location": {
+      "path": "/home/user/.vscode/extensions/github.copilot-1.200.0",
+      "scheme": "file"
+    },
+    "relativeLocation": "github.copilot-1.200.0"
+  }
+]

--- a/pkg/aitool/ide_extension.go
+++ b/pkg/aitool/ide_extension.go
@@ -1,0 +1,45 @@
+package aitool
+
+import (
+	"context"
+
+	"github.com/safedep/vet/pkg/common/logger"
+	"github.com/safedep/vet/pkg/readers"
+)
+
+// ideExtensionApp is intentionally singular ("ide_extension"), distinct from
+// ideExtensionsApp ("ide_extensions") used by the AI-extension discoverer.
+// Different app ids produce different item_identity hashes, keeping the
+// IDE-extension and AI-extension facets separate in the endpoint catalog.
+const ideExtensionApp = "ide_extension"
+
+type ideExtensionDiscoverer struct {
+	config DiscoveryConfig
+	// reader is injected in tests; nil means use the real default distributions.
+	reader vsixManifestReader
+}
+
+func NewIDEExtensionDiscoverer(config DiscoveryConfig) (AIToolReader, error) {
+	return &ideExtensionDiscoverer{config: config}, nil
+}
+
+func (d *ideExtensionDiscoverer) Name() string { return "IDE Extensions" }
+func (d *ideExtensionDiscoverer) App() string  { return ideExtensionApp }
+
+func (d *ideExtensionDiscoverer) EnumTools(_ context.Context, handler AIToolHandlerFn) error {
+	if !d.config.ScopeEnabled(AIToolScopeSystem) {
+		return nil
+	}
+
+	r := d.reader
+	if r == nil {
+		var err error
+		r, err = readers.NewVSIXExtReaderFromDefaultDistributions()
+		if err != nil {
+			logger.Debugf("IDE extensions unavailable: %v", err)
+			return nil
+		}
+	}
+
+	return enumVSIXExtensions(r, ideExtensionApp, AIToolTypeIDEExtension, acceptAll, handler)
+}

--- a/pkg/aitool/ide_extension.go
+++ b/pkg/aitool/ide_extension.go
@@ -41,5 +41,6 @@ func (d *ideExtensionDiscoverer) EnumTools(_ context.Context, handler AIToolHand
 		}
 	}
 
-	return enumVSIXExtensions(r, ideExtensionApp, AIToolTypeIDEExtension, acceptAll, handler)
+	return enumVSIXExtensions(r, ideExtensionApp, AIToolTypeIDEExtension,
+		func(id string) (string, bool) { return id, true }, handler)
 }

--- a/pkg/aitool/ide_extension_test.go
+++ b/pkg/aitool/ide_extension_test.go
@@ -1,0 +1,130 @@
+package aitool
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/safedep/vet/pkg/readers"
+)
+
+func TestIDEExtensionDiscoverer_Interface(t *testing.T) {
+	d := &ideExtensionDiscoverer{}
+	assert.Equal(t, "IDE Extensions", d.Name())
+	assert.Equal(t, ideExtensionApp, d.App())
+}
+
+func TestIDEExtensionDiscoverer_EmitsAllExtensions(t *testing.T) {
+	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
+	r, err := readers.NewVSIXExtReader([]string{fixturePath})
+	require.NoError(t, err)
+
+	d := &ideExtensionDiscoverer{
+		config: DiscoveryConfig{},
+		reader: r,
+	}
+
+	var tools []*AITool
+	err = d.EnumTools(context.Background(), func(tool *AITool) error {
+		tools = append(tools, tool)
+		return nil
+	})
+
+	require.NoError(t, err)
+	// Both AI and non-AI extensions must be reported
+	require.Len(t, tools, 2, "all installed extensions must be emitted regardless of AI status")
+}
+
+func TestIDEExtensionDiscoverer_ToolType(t *testing.T) {
+	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
+	r, err := readers.NewVSIXExtReader([]string{fixturePath})
+	require.NoError(t, err)
+
+	d := &ideExtensionDiscoverer{config: DiscoveryConfig{}, reader: r}
+
+	err = d.EnumTools(context.Background(), func(tool *AITool) error {
+		assert.Equal(t, AIToolTypeIDEExtension, tool.Type)
+		assert.Equal(t, AIToolScopeSystem, tool.Scope)
+		return nil
+	})
+
+	require.NoError(t, err)
+}
+
+func TestIDEExtensionDiscoverer_ExtensionMetadata(t *testing.T) {
+	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
+	r, err := readers.NewVSIXExtReader([]string{fixturePath})
+	require.NoError(t, err)
+
+	d := &ideExtensionDiscoverer{config: DiscoveryConfig{}, reader: r}
+
+	byID := map[string]*AITool{}
+	err = d.EnumTools(context.Background(), func(tool *AITool) error {
+		id, _ := tool.GetMeta("extension.id").(string)
+		byID[id] = tool
+		return nil
+	})
+	require.NoError(t, err)
+
+	t.Run("non-AI extension included", func(t *testing.T) {
+		tool, ok := byID["ms-python.python"]
+		require.True(t, ok)
+		assert.Equal(t, "ms-python.python", tool.Name)
+		assert.Equal(t, "2023.20.0", tool.GetMeta("extension.version"))
+		assert.Equal(t, "VS Code", tool.GetMeta("extension.ide"))
+		assert.NotEmpty(t, tool.ID)
+		assert.NotEmpty(t, tool.SourceID)
+	})
+
+	t.Run("AI extension included", func(t *testing.T) {
+		tool, ok := byID["github.copilot"]
+		require.True(t, ok)
+		assert.Equal(t, "github.copilot", tool.Name)
+		assert.Equal(t, "1.200.0", tool.GetMeta("extension.version"))
+	})
+}
+
+func TestIDEExtensionDiscoverer_SystemScopeOnly(t *testing.T) {
+	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
+	r, err := readers.NewVSIXExtReader([]string{fixturePath})
+	require.NoError(t, err)
+
+	// Only project scope enabled — system scope (extensions) must be skipped.
+	projectOnlyScope, err := NewDiscoveryScope(AIToolScopeProject)
+	require.NoError(t, err)
+
+	d := &ideExtensionDiscoverer{
+		config: DiscoveryConfig{Scope: projectOnlyScope},
+		reader: r,
+	}
+
+	var count int
+	err = d.EnumTools(context.Background(), func(*AITool) error {
+		count++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "no extensions emitted when system scope is not enabled")
+}
+
+func TestIDEExtensionDiscoverer_StableIdentity(t *testing.T) {
+	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
+
+	collectIDs := func() map[string]string {
+		r, err := readers.NewVSIXExtReader([]string{fixturePath})
+		require.NoError(t, err)
+		d := &ideExtensionDiscoverer{config: DiscoveryConfig{}, reader: r}
+		ids := map[string]string{}
+		_ = d.EnumTools(context.Background(), func(tool *AITool) error {
+			ids[tool.GetMeta("extension.id").(string)] = tool.ID
+			return nil
+		})
+		return ids
+	}
+
+	assert.Equal(t, collectIDs(), collectIDs(), "item_identity must be deterministic across runs")
+}

--- a/pkg/aitool/ide_extension_test.go
+++ b/pkg/aitool/ide_extension_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/safedep/vet/pkg/readers"
 )
 
+func newFixtureDiscoverer(t testing.TB, config DiscoveryConfig) *ideExtensionDiscoverer {
+	t.Helper()
+	r, err := readers.NewVSIXExtReader([]string{filepath.Join("fixtures/ide_extension/.vscode/extensions")})
+	require.NoError(t, err)
+	return &ideExtensionDiscoverer{config: config, reader: r}
+}
+
 func TestIDEExtensionDiscoverer_Interface(t *testing.T) {
 	d := &ideExtensionDiscoverer{}
 	assert.Equal(t, "IDE Extensions", d.Name())
@@ -18,34 +25,22 @@ func TestIDEExtensionDiscoverer_Interface(t *testing.T) {
 }
 
 func TestIDEExtensionDiscoverer_EmitsAllExtensions(t *testing.T) {
-	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
-	r, err := readers.NewVSIXExtReader([]string{fixturePath})
-	require.NoError(t, err)
-
-	d := &ideExtensionDiscoverer{
-		config: DiscoveryConfig{},
-		reader: r,
-	}
+	d := newFixtureDiscoverer(t, DiscoveryConfig{})
 
 	var tools []*AITool
-	err = d.EnumTools(context.Background(), func(tool *AITool) error {
+	err := d.EnumTools(context.Background(), func(tool *AITool) error {
 		tools = append(tools, tool)
 		return nil
 	})
 
 	require.NoError(t, err)
-	// Both AI and non-AI extensions must be reported
 	require.Len(t, tools, 2, "all installed extensions must be emitted regardless of AI status")
 }
 
 func TestIDEExtensionDiscoverer_ToolType(t *testing.T) {
-	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
-	r, err := readers.NewVSIXExtReader([]string{fixturePath})
-	require.NoError(t, err)
+	d := newFixtureDiscoverer(t, DiscoveryConfig{})
 
-	d := &ideExtensionDiscoverer{config: DiscoveryConfig{}, reader: r}
-
-	err = d.EnumTools(context.Background(), func(tool *AITool) error {
+	err := d.EnumTools(context.Background(), func(tool *AITool) error {
 		assert.Equal(t, AIToolTypeIDEExtension, tool.Type)
 		assert.Equal(t, AIToolScopeSystem, tool.Scope)
 		return nil
@@ -55,14 +50,10 @@ func TestIDEExtensionDiscoverer_ToolType(t *testing.T) {
 }
 
 func TestIDEExtensionDiscoverer_ExtensionMetadata(t *testing.T) {
-	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
-	r, err := readers.NewVSIXExtReader([]string{fixturePath})
-	require.NoError(t, err)
-
-	d := &ideExtensionDiscoverer{config: DiscoveryConfig{}, reader: r}
+	d := newFixtureDiscoverer(t, DiscoveryConfig{})
 
 	byID := map[string]*AITool{}
-	err = d.EnumTools(context.Background(), func(tool *AITool) error {
+	err := d.EnumTools(context.Background(), func(tool *AITool) error {
 		id, _ := tool.GetMeta("extension.id").(string)
 		byID[id] = tool
 		return nil
@@ -88,18 +79,10 @@ func TestIDEExtensionDiscoverer_ExtensionMetadata(t *testing.T) {
 }
 
 func TestIDEExtensionDiscoverer_SystemScopeOnly(t *testing.T) {
-	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
-	r, err := readers.NewVSIXExtReader([]string{fixturePath})
-	require.NoError(t, err)
-
-	// Only project scope enabled — system scope (extensions) must be skipped.
 	projectOnlyScope, err := NewDiscoveryScope(AIToolScopeProject)
 	require.NoError(t, err)
 
-	d := &ideExtensionDiscoverer{
-		config: DiscoveryConfig{Scope: projectOnlyScope},
-		reader: r,
-	}
+	d := newFixtureDiscoverer(t, DiscoveryConfig{Scope: projectOnlyScope})
 
 	var count int
 	err = d.EnumTools(context.Background(), func(*AITool) error {
@@ -112,12 +95,8 @@ func TestIDEExtensionDiscoverer_SystemScopeOnly(t *testing.T) {
 }
 
 func TestIDEExtensionDiscoverer_StableIdentity(t *testing.T) {
-	fixturePath := filepath.Join("fixtures/ide_extension/.vscode/extensions")
-
 	collectIDs := func() map[string]string {
-		r, err := readers.NewVSIXExtReader([]string{fixturePath})
-		require.NoError(t, err)
-		d := &ideExtensionDiscoverer{config: DiscoveryConfig{}, reader: r}
+		d := newFixtureDiscoverer(t, DiscoveryConfig{})
 		ids := map[string]string{}
 		_ = d.EnumTools(context.Background(), func(tool *AITool) error {
 			ids[tool.GetMeta("extension.id").(string)] = tool.ID

--- a/pkg/aitool/model.go
+++ b/pkg/aitool/model.go
@@ -14,6 +14,7 @@ const (
 	AIToolTypeMCPServer     AIToolType = "mcp_server"
 	AIToolTypeCodingAgent   AIToolType = "coding_agent"
 	AIToolTypeAIExtension   AIToolType = "ai_extension"
+	AIToolTypeIDEExtension  AIToolType = "ide_extension"
 	AIToolTypeCLITool       AIToolType = "cli_tool"
 	AIToolTypeProjectConfig AIToolType = "project_config"
 )
@@ -27,6 +28,8 @@ func (t AIToolType) DisplayName() string {
 		return "Coding Agent"
 	case AIToolTypeAIExtension:
 		return "AI Extension"
+	case AIToolTypeIDEExtension:
+		return "IDE Extension"
 	case AIToolTypeCLITool:
 		return "CLI Tool"
 	case AIToolTypeProjectConfig:

--- a/pkg/aitool/vsix_extensions.go
+++ b/pkg/aitool/vsix_extensions.go
@@ -1,0 +1,61 @@
+package aitool
+
+import (
+	"strings"
+
+	"github.com/safedep/vet/pkg/models"
+	"github.com/safedep/vet/pkg/readers"
+)
+
+// vsixManifestReader is the minimal interface needed by VSIX extension discoverers.
+type vsixManifestReader interface {
+	EnumManifests(func(*models.PackageManifest, readers.PackageReader) error) error
+}
+
+// extensionNameFn resolves a display name for a lowercased extension id.
+// Returning ok=false skips the extension.
+type extensionNameFn func(id string) (name string, ok bool)
+
+// acceptAll accepts every extension, using the raw id as the display name.
+func acceptAll(id string) (string, bool) { return id, true }
+
+// enumVSIXExtensions iterates all extensions from r and calls handler for each
+// accepted one. The caller handles scope-gating and reader construction.
+func enumVSIXExtensions(
+	r vsixManifestReader,
+	app string,
+	toolType AIToolType,
+	nameFor extensionNameFn,
+	handler AIToolHandlerFn,
+) error {
+	return r.EnumManifests(func(manifest *models.PackageManifest, pr readers.PackageReader) error {
+		return pr.EnumPackages(func(pkg *models.Package) error {
+			name, ok := nameFor(strings.ToLower(pkg.Name))
+			if !ok {
+				return nil
+			}
+
+			tool := &AITool{
+				Name:       name,
+				Type:       toolType,
+				Scope:      AIToolScopeSystem,
+				App:        app,
+				AppDisplay: app,
+				ConfigPath: manifest.GetPath(),
+			}
+
+			tool.ID = generateID(tool.App, string(tool.Type), string(tool.Scope), pkg.Name, tool.ConfigPath)
+			tool.SourceID = generateSourceID(tool.App, tool.ConfigPath)
+			tool.SetMeta("extension.id", pkg.Name)
+			tool.SetMeta("extension.version", pkg.Version)
+			tool.SetMeta("extension.ecosystem", manifest.Ecosystem)
+
+			if ide := ideNameFromPath(manifest.GetPath()); ide != "" {
+				tool.SetMeta("extension.ide", ide)
+				tool.AppDisplay = ide
+			}
+
+			return handler(tool)
+		})
+	})
+}

--- a/pkg/aitool/vsix_extensions.go
+++ b/pkg/aitool/vsix_extensions.go
@@ -12,20 +12,15 @@ type vsixManifestReader interface {
 	EnumManifests(func(*models.PackageManifest, readers.PackageReader) error) error
 }
 
-// extensionNameFn resolves a display name for a lowercased extension id.
-// Returning ok=false skips the extension.
-type extensionNameFn func(id string) (name string, ok bool)
-
-// acceptAll accepts every extension, using the raw id as the display name.
-func acceptAll(id string) (string, bool) { return id, true }
-
 // enumVSIXExtensions iterates all extensions from r and calls handler for each
-// accepted one. The caller handles scope-gating and reader construction.
+// accepted one. nameFor receives the lowercased extension id and returns the
+// display name; returning ok=false skips the extension. The caller handles
+// scope-gating and reader construction.
 func enumVSIXExtensions(
 	r vsixManifestReader,
 	app string,
 	toolType AIToolType,
-	nameFor extensionNameFn,
+	nameFor func(id string) (name string, ok bool),
 	handler AIToolHandlerFn,
 ) error {
 	return r.EnumManifests(func(manifest *models.PackageManifest, pr readers.PackageReader) error {

--- a/pkg/inventory/scanners/aitool/translate.go
+++ b/pkg/inventory/scanners/aitool/translate.go
@@ -68,6 +68,8 @@ func translateKind(t aitool.AIToolType) inventory.Kind {
 		return inventory.KindCodingAgent
 	case aitool.AIToolTypeAIExtension:
 		return inventory.KindAIExtension
+	case aitool.AIToolTypeIDEExtension:
+		return inventory.KindIDEExtension
 	case aitool.AIToolTypeCLITool:
 		return inventory.KindCLITool
 	case aitool.AIToolTypeProjectConfig:

--- a/pkg/inventory/scanners/aitool/translate_test.go
+++ b/pkg/inventory/scanners/aitool/translate_test.go
@@ -179,6 +179,30 @@ func TestTranslateProjectConfig(t *testing.T) {
 	assert.Equal(t, []string{"/work/repo/CLAUDE.md"}, item.Agent.InstructionFiles)
 }
 
+func TestTranslateIDEExtensionStoresExtensionMetadata(t *testing.T) {
+	tool := &aitool.AITool{
+		Name:       "ms-python.python",
+		Type:       aitool.AIToolTypeIDEExtension,
+		Scope:      aitool.AIToolScopeSystem,
+		App:        "ide_extension",
+		AppDisplay: "VS Code",
+		ConfigPath: "/home/u/.vscode/extensions/extensions.json",
+		Metadata: map[string]any{
+			metaKeyExtensionID:      "ms-python.python",
+			metaKeyExtensionVersion: "2024.1.0",
+			metaKeyExtensionIDE:     "VS Code",
+		},
+	}
+
+	item := translate(tool)
+	require.NotNil(t, item)
+	assert.Equal(t, inventory.KindIDEExtension, item.Kind)
+	assert.Equal(t, "ms-python.python", item.Metadata[metaKeyExtensionID])
+	assert.Equal(t, "2024.1.0", item.Metadata[metaKeyExtensionVersion])
+	assert.Equal(t, "VS Code", item.Metadata[metaKeyExtensionIDE])
+	assert.Equal(t, "VS Code", item.Metadata[metaKeyAppDisplay])
+}
+
 func TestTranslateUnknownTypeDegradesToUnspecified(t *testing.T) {
 	tool := &aitool.AITool{
 		Name:       "weird",

--- a/pkg/inventory/scanners/scanners.go
+++ b/pkg/inventory/scanners/scanners.go
@@ -32,8 +32,9 @@ type Descriptor struct {
 // Kind values accepted on the --kind flag and consumed by callers that
 // pin a specific scanner (e.g. cmd/ai/discover).
 const (
-	KindAITool     = "ai-tool"
-	KindAgentSkill = "agent-skill"
+	KindAITool       = "ai-tool"
+	KindAgentSkill   = "agent-skill"
+	KindIDEExtension = "ide-extension"
 )
 
 // registry is the shipped set of scanner declarations. Adding a scanner
@@ -49,6 +50,16 @@ var registry = []Descriptor{
 		Kind: KindAgentSkill,
 		New: func() inventory.Scanner {
 			return skillsscanner.New()
+		},
+	},
+	{
+		// ide-extension uses an isolated registry so it never leaks into
+		// vet ai discover, which pins {ai-tool, agent-skill} explicitly.
+		Kind: KindIDEExtension,
+		New: func() inventory.Scanner {
+			reg := aitool.NewRegistry()
+			reg.Register("ide_extension", aitool.NewIDEExtensionDiscoverer)
+			return aitoolscanner.New(reg)
 		},
 	},
 }

--- a/pkg/inventory/scanners/scanners_test.go
+++ b/pkg/inventory/scanners/scanners_test.go
@@ -52,6 +52,14 @@ func TestAllowedKindsReturnsIndependentSlice(t *testing.T) {
 		"AllowedKinds must not expose the internal slice")
 }
 
+func TestIDEExtensionKindIsRegistered(t *testing.T) {
+	assert.Contains(t, AllowedKinds(), KindIDEExtension)
+
+	got, err := Build([]string{KindIDEExtension})
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+}
+
 func TestRegistryEntriesAreUniqueByKind(t *testing.T) {
 	seen := make(map[string]struct{}, len(registry))
 	for _, d := range registry {

--- a/pkg/readers/vsix_ext_reader.go
+++ b/pkg/readers/vsix_ext_reader.go
@@ -16,26 +16,11 @@ const (
 )
 
 var editors = map[string]distributionInfo{
-	"code": {
-		FilePath:  ".vscode/extensions",
-		Ecosystem: models.EcosystemVSCodeExtensions,
-	},
-	"vscodium": {
-		FilePath:  ".vscode-oss/extensions",
-		Ecosystem: models.EcosystemOpenVSXExtensions,
-	},
-	"cursor": {
-		FilePath:  ".cursor/extensions",
-		Ecosystem: models.EcosystemOpenVSXExtensions,
-	},
-	"windsurf": {
-		FilePath:  ".windsurf/extensions",
-		Ecosystem: models.EcosystemOpenVSXExtensions,
-	},
-	"antigravity": {
-		FilePath:  ".antigravity/extensions",
-		Ecosystem: models.EcosystemOpenVSXExtensions,
-	},
+	"code":        {FilePath: ".vscode/extensions", Ecosystem: models.EcosystemVSCodeExtensions, DisplayName: "VS Code"},
+	"vscodium":    {FilePath: ".vscode-oss/extensions", Ecosystem: models.EcosystemOpenVSXExtensions, DisplayName: "VSCodium"},
+	"cursor":      {FilePath: ".cursor/extensions", Ecosystem: models.EcosystemOpenVSXExtensions, DisplayName: "Cursor"},
+	"windsurf":    {FilePath: ".windsurf/extensions", Ecosystem: models.EcosystemOpenVSXExtensions, DisplayName: "Windsurf"},
+	"antigravity": {FilePath: ".antigravity/extensions", Ecosystem: models.EcosystemOpenVSXExtensions, DisplayName: "Antigravity"},
 }
 
 type vsCodeExtensionIdentifier struct {
@@ -60,8 +45,9 @@ type vsCodeExtensionList struct {
 }
 
 type distributionInfo struct {
-	FilePath  string // Path to the extensions directory
-	Ecosystem string // Type of extension marketplace (VSCode or OpenVSX)
+	FilePath    string
+	Ecosystem   string
+	DisplayName string
 }
 
 type vsixExtReader struct {
@@ -105,6 +91,18 @@ func detectEcosystem(distribution string) string {
 
 		if distBase == ecoBase && distEditor == ecoEditor {
 			return eco.Ecosystem
+		}
+	}
+	return ""
+}
+
+// EditorDisplayName returns the display name for an IDE given the base name of
+// its extensions parent directory (e.g. ".vscode" → "VS Code"). Returns empty
+// string for unrecognised dirs.
+func EditorDisplayName(extDirBase string) string {
+	for _, e := range editors {
+		if filepath.Base(filepath.Dir(e.FilePath)) == extDirBase {
+			return e.DisplayName
 		}
 	}
 	return ""

--- a/pkg/readers/vsix_ext_reader.go
+++ b/pkg/readers/vsix_ext_reader.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/safedep/vet/pkg/common/logger"
 	"github.com/safedep/vet/pkg/models"
@@ -75,29 +74,40 @@ func NewVSIXExtReader(distributions []string) (*vsixExtReader, error) {
 	customDistributions := make(map[string]distributionInfo)
 
 	for i, distribution := range distributions {
-		// Check if the path matches any supported editor
-		foundMatch := false
-		ecosystem := models.EcosystemVSCodeExtensions
-
-		for _, eco := range editors {
-			if strings.Contains(distribution, eco.FilePath) {
-				ecosystem = eco.Ecosystem
-				foundMatch = true
-				break
-			}
-		}
-
-		if !foundMatch {
+		eco := detectEcosystem(distribution)
+		if eco == "" {
 			return nil, fmt.Errorf("unsupported editor path: %s", distribution)
 		}
 
 		customDistributions[fmt.Sprintf("custom-%d", i)] = distributionInfo{
 			FilePath:  distribution,
-			Ecosystem: ecosystem,
+			Ecosystem: eco,
 		}
 	}
 
 	return newVSCodeExtReaderFromDistributions(customDistributions)
+}
+
+// detectEcosystem returns the marketplace ecosystem for a given extensions
+// directory path by comparing path components, not substrings. This handles
+// OS-native path separators correctly on all platforms (\ on Windows, / on
+// Linux and macOS).
+func detectEcosystem(distribution string) string {
+	// Compare the last two path components (e.g. ".vscode" / "extensions")
+	// against the known editor patterns so no string/separator assumptions
+	// are made.
+	distBase := filepath.Base(distribution)                 // "extensions"
+	distEditor := filepath.Base(filepath.Dir(distribution)) // ".vscode"
+
+	for _, eco := range editors {
+		ecoBase := filepath.Base(eco.FilePath)                 // "extensions"
+		ecoEditor := filepath.Base(filepath.Dir(eco.FilePath)) // ".vscode"
+
+		if distBase == ecoBase && distEditor == ecoEditor {
+			return eco.Ecosystem
+		}
+	}
+	return ""
 }
 
 func NewVSIXExtReaderFromDefaultDistributions() (*vsixExtReader, error) {

--- a/pkg/readers/vsix_ext_reader_test.go
+++ b/pkg/readers/vsix_ext_reader_test.go
@@ -129,3 +129,54 @@ func TestVSCodeExtReaderWithInvalidPath(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, reader)
 }
+
+// TestVSCodeExtReaderEcosystemDetection verifies that ecosystem detection uses
+// filepath component comparison so it is correct on all platforms regardless
+// of path separator. Paths are constructed with filepath.Join to match how
+// NewVSIXExtReaderFromDefaultDistributions builds them at runtime.
+func TestVSCodeExtReaderEcosystemDetection(t *testing.T) {
+	home := "/home/user"
+
+	tests := []struct {
+		name        string
+		path        string
+		expectedEco string
+	}{
+		{
+			name:        "VSCode path",
+			path:        filepath.Join(home, ".vscode", "extensions"),
+			expectedEco: models.EcosystemVSCodeExtensions,
+		},
+		{
+			name:        "VSCodium path",
+			path:        filepath.Join(home, ".vscode-oss", "extensions"),
+			expectedEco: models.EcosystemOpenVSXExtensions,
+		},
+		{
+			name:        "Cursor path",
+			path:        filepath.Join(home, ".cursor", "extensions"),
+			expectedEco: models.EcosystemOpenVSXExtensions,
+		},
+		{
+			name:        "Windsurf path",
+			path:        filepath.Join(home, ".windsurf", "extensions"),
+			expectedEco: models.EcosystemOpenVSXExtensions,
+		},
+		{
+			name:        "Antigravity path",
+			path:        filepath.Join(home, ".antigravity", "extensions"),
+			expectedEco: models.EcosystemOpenVSXExtensions,
+		},
+		{
+			name:        "unknown path returns empty",
+			path:        filepath.Join(home, ".unknown-editor", "extensions"),
+			expectedEco: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedEco, detectEcosystem(tt.path))
+		})
+	}
+}


### PR DESCRIPTION
also fixes a bug with filepath manipulation by replacing adhoc string manip with actual `path/filepath` routines.
