### PR TITLE
fix: map cargo PURL to canonical ecosystem so malware is detected

### DIFF
--- a/pkg/common/purl/purl.go
+++ b/pkg/common/purl/purl.go
@@ -65,7 +65,13 @@ func purlBuildLockfilePackageName(ecosystem lockfile.Ecosystem, group, name stri
 
 func PurlTypeToEcosystem(purlType string) (lockfile.Ecosystem, error) {
 	knownTypes := map[string]lockfile.Ecosystem{
-		packageurl.TypeCargo:    lockfile.CargoEcosystem,
+		// osv-scanner's lockfile.CargoEcosystem is "crates.io" which does not
+		// match vet's canonical model ecosystem ("Cargo"). Returning the raw
+		// lockfile value makes GetControlTowerSpecEcosystem() resolve to
+		// ECOSYSTEM_UNSPECIFIED, silently disabling malware/insights enrichment
+		// for cargo PURLs. Map to the model ecosystem like we do for the
+		// GitHub Actions / VSCode / OpenVSX types below.
+		packageurl.TypeCargo:    lockfile.Ecosystem(models.EcosystemCargo),
 		packageurl.TypeComposer: lockfile.ComposerEcosystem,
 		packageurl.TypeGolang:   lockfile.GoEcosystem,
 		packageurl.TypeMaven:    lockfile.MavenEcosystem,

--- a/pkg/common/utils/sbom/sbom_test.go
+++ b/pkg/common/utils/sbom/sbom_test.go
@@ -22,7 +22,7 @@ func TestParsePurlType(t *testing.T) {
 		{"nuget", lockfile.NuGetEcosystem, true},
 		{"composer", lockfile.ComposerEcosystem, true},
 		{"pypi", lockfile.PipEcosystem, true},
-		{"cargo", lockfile.CargoEcosystem, true},
+		{"cargo", lockfile.Ecosystem(models.EcosystemCargo), true},
 		{"gem", lockfile.BundlerEcosystem, true}, // Update with the expected ecosystem for Ruby
 		// Add more test cases here
 	}

--- a/pkg/readers/purl_reader_test.go
+++ b/pkg/readers/purl_reader_test.go
@@ -113,6 +113,16 @@ func TestPurlReaderWithMultiplePURLS(t *testing.T) {
 			"@kunalsin9h/load-gql",
 			"1.0.2",
 		},
+		{
+			// Regression: cargo PURLs must resolve to the canonical "Cargo"
+			// model ecosystem (not osv-scanner's "crates.io") so that malware
+			// and insights enrichment is not silently disabled.
+			"Cargo PURL",
+			"pkg:cargo/serde@1.0.0",
+			"Cargo",
+			"serde",
+			"1.0.0",
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
vet scan --purl pkg:cargo/... never queried malware analysis for the correct ecosystem. PurlTypeToEcosystem("cargo") returned lockfile.CargoEcosystem ("crates.io"), but GetControlTowerSpecEcosystem switches on vet's model ecosystem constants (EcosystemCargo == "Cargo"), so it fell through to ECOSYSTEM_UNSPECIFIED and the malware query was sent without an ecosystem. Cargo was the only mismatch since other osv-scanner ecosystem strings coincidentally equal vet's model constants.

Map cargo to the canonical model ecosystem, consistent with the existing GitHub Actions / VSCode / OpenVSX entries.