### PR TITLE
fix: render lockfile poisoning findings for non-http(s) resolved URLs

### DIFF
--- a/pkg/reporter/lfp_aggregation.go
+++ b/pkg/reporter/lfp_aggregation.go
@@ -4,11 +4,18 @@ import (
 	"regexp"
 )
 
-// lfpURLRe extracts the first https URL from backtick-quotes in a lockfile poisoning message.
+// lfpURLRe extracts the resolved URL from backtick-quotes in a lockfile poisoning message.
 // Messages look like:
 //
 //	Package `name` resolved to an untrusted host `https://...`
-var lfpURLRe = regexp.MustCompile("`(https?://[^`]+)`")
+//	Package `name` resolved to an untrusted host `git+ssh://...`
+//
+// The scheme is intentionally generic (not just http/https) because npm lockfiles
+// can resolve packages to git+ssh, git+https, git, ssh, etc. Restricting this to
+// http(s) caused such findings to be silently dropped, producing an empty
+// "Lockfile Poisoning Detected" section. The package name is the first backtick
+// group and does not contain "://", so the URL group is matched unambiguously.
+var lfpURLRe = regexp.MustCompile("`([a-zA-Z][a-zA-Z0-9+.-]*://[^`]+)`")
 
 // Package `name` resolved to an URL `https://...` that does not follow...
 var lfpPackageNameConventionRe = regexp.MustCompile("package name path convention")

--- a/pkg/reporter/lfp_aggregation_test.go
+++ b/pkg/reporter/lfp_aggregation_test.go
@@ -1,0 +1,61 @@
+package reporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregateLFPMessages(t *testing.T) {
+	t.Run("http and https urls are aggregated", func(t *testing.T) {
+		groups := aggregateLFPMessages([]string{
+			"Package `ok` resolved to an untrusted host `https://my-registry.internal/ok/-/ok-1.0.0.tgz`",
+		})
+		assert.Len(t, groups, 1)
+		assert.Equal(t, "https://my-registry.internal/ok/-/ok-1.0.0.tgz", groups[0].url)
+		assert.Equal(t, []string{"ok"}, groups[0].pkgOrder)
+	})
+
+	// Regression: non-http(s) schemes (git deps) must not be silently dropped.
+	// Previously lfpURLRe only matched http(s), so these findings disappeared and
+	// the "Lockfile Poisoning Detected" section rendered empty.
+	t.Run("git scheme urls are not dropped", func(t *testing.T) {
+		cases := []struct {
+			name string
+			msg  string
+			url  string
+		}{
+			{"git+ssh", "Package `glob` resolved to an untrusted host `git+ssh://git@github.com/isaacs/node-glob.git#abc`", "git+ssh://git@github.com/isaacs/node-glob.git#abc"},
+			{"git+https", "Package `foo` resolved to an untrusted host `git+https://github.com/u/foo.git#deadbeef`", "git+https://github.com/u/foo.git#deadbeef"},
+			{"git", "Package `bar` resolved to an untrusted host `git://github.com/u/bar.git`", "git://github.com/u/bar.git"},
+			{"ssh", "Package `baz` resolved to an untrusted host `ssh://git@github.com/u/baz.git`", "ssh://git@github.com/u/baz.git"},
+		}
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				groups := aggregateLFPMessages([]string{c.msg})
+				assert.Len(t, groups, 1)
+				assert.Equal(t, c.url, groups[0].url)
+			})
+		}
+	})
+
+	t.Run("path convention flag is detected", func(t *testing.T) {
+		groups := aggregateLFPMessages([]string{
+			"Package `foo` resolved to an URL `git+ssh://git@github.com/u/foo.git#x` that does not follow the package name path convention",
+		})
+		assert.Len(t, groups, 1)
+		assert.True(t, groups[0].doesNotFollowPathConvention)
+	})
+
+	t.Run("same url across signals is aggregated into one group", func(t *testing.T) {
+		url := "git+ssh://git@github.com/u/foo.git#x"
+		groups := aggregateLFPMessages([]string{
+			"Package `foo` resolved to an untrusted host `" + url + "`",
+			"Package `foo` resolved to an URL `" + url + "` that does not follow the package name path convention",
+		})
+		assert.Len(t, groups, 1)
+		assert.Equal(t, []string{"foo"}, groups[0].pkgOrder)
+		assert.True(t, groups[0].doesNotFollowPathConvention)
+	})
+}


### PR DESCRIPTION
## Problem

Users on v1.17.3 reported a `** Lockfile Poisoning Detected` section with **no findings under it** — the header prints but the body is empty.

## Root cause

The console (`summary.go`) and markdown (`markdown_summary.go`) reporters aggregate lockfile poisoning findings by re-parsing the analyzer's free-text messages with regex (`aggregateLFPMessages`). The URL-extraction regex only matched http(s):

```go
var lfpURLRe = regexp.MustCompile("`(https?://[^`]+)`")
```

The npm analyzer legitimately flags packages resolving to **any untrusted scheme** — including `git+ssh://`, `git+https://`, `git://`, `ssh://` (common for git dependencies). Those messages failed the regex and were silently dropped during aggregation (the `continue` in the loop).

The section header gates on the raw event count (`len(r.lockfilePoisoning) > 0`), while the body iterates over the *aggregated* groups. So a lockfile whose poisoning findings were all on non-http(s) URLs rendered the header with an empty body.

This was introduced in v1.17.3 by `add61ab` ("consolidate lockfile poisoning output by URL"), which added the reporter-side string re-parsing. Before that, the reporter printed each raw message directly, so all schemes always showed.

## Fix

Relax `lfpURLRe` to match any URL scheme (`[a-zA-Z][a-zA-Z0-9+.-]*://`). The package name is the first backtick group and never contains `://`, so the URL group is still matched unambiguously.

## Testing

Added `pkg/reporter/lfp_aggregation_test.go` with regression coverage for `git+ssh`, `git+https`, `git`, and `ssh` schemes, plus existing http(s) and path-convention cases.

Verified end-to-end on a lockfile mixing all schemes:

**Before:** only `http://` and `https://` packages shown; the three git-based deps dropped.
**After:** all five untrusted URLs render; trusted `registry.npmjs.org` correctly not flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)