### PR TITLE
fix(mcp): return structured ERROR responses for upstream tool failures

### DIFF
--- a/mcp/tools/common.go
+++ b/mcp/tools/common.go
@@ -3,7 +3,19 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
+
+const (
+	llmResponseTypeError = "ERROR"
+)
+
+type llmErrorResponse struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Code    string `json:"code,omitempty"`
+}
 
 func serializeForLlm(msg any) (string, error) {
 	json, err := json.Marshal(msg)
@@ -12,4 +24,21 @@ func serializeForLlm(msg any) (string, error) {
 	}
 
 	return fmt.Sprintf("```json\n%s\n```", string(json)), nil
+}
+
+func serializeErrorForLlm(message, code string) (string, error) {
+	return serializeForLlm(llmErrorResponse{
+		Type:    llmResponseTypeError,
+		Message: message,
+		Code:    code,
+	})
+}
+
+func toolResultFromLlmError(message, code string) (*mcpgo.CallToolResult, error) {
+	serialized, err := serializeErrorForLlm(message, code)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize error response: %w", err)
+	}
+
+	return mcpgo.NewToolResultText(serialized), nil
 }

--- a/mcp/tools/common.go
+++ b/mcp/tools/common.go
@@ -8,7 +8,9 @@ import (
 )
 
 const (
-	llmResponseTypeError = "ERROR"
+	llmResponseTypeError               = "ERROR"
+	llmErrorCodePackageInsightNotFound = "PACKAGE_INSIGHT_NOT_FOUND"
+	llmErrorCodeUpstreamError          = "UPSTREAM_ERROR"
 )
 
 type llmErrorResponse struct {

--- a/mcp/tools/common_test.go
+++ b/mcp/tools/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSerializeForLlm(t *testing.T) {
@@ -67,4 +68,22 @@ func TestSerializeForLlm(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSerializeErrorForLlm(t *testing.T) {
+	result, err := serializeErrorForLlm("package insights unavailable", "PACKAGE_INSIGHT_NOT_FOUND")
+
+	assert.NoError(t, err)
+	assert.Contains(t, result, `"type":"ERROR"`)
+	assert.Contains(t, result, "package insights unavailable")
+	assert.Contains(t, result, "PACKAGE_INSIGHT_NOT_FOUND")
+}
+
+func TestToolResultFromLlmError(t *testing.T) {
+	result, err := toolResultFromLlmError("upstream failure", "UPSTREAM_ERROR")
+
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+	assert.Len(t, result.Content, 1)
 }

--- a/mcp/tools/common_test.go
+++ b/mcp/tools/common_test.go
@@ -71,16 +71,16 @@ func TestSerializeForLlm(t *testing.T) {
 }
 
 func TestSerializeErrorForLlm(t *testing.T) {
-	result, err := serializeErrorForLlm("package insights unavailable", "PACKAGE_INSIGHT_NOT_FOUND")
+	result, err := serializeErrorForLlm("package insights unavailable", llmErrorCodePackageInsightNotFound)
 
 	assert.NoError(t, err)
 	assert.Contains(t, result, `"type":"ERROR"`)
 	assert.Contains(t, result, "package insights unavailable")
-	assert.Contains(t, result, "PACKAGE_INSIGHT_NOT_FOUND")
+	assert.Contains(t, result, llmErrorCodePackageInsightNotFound)
 }
 
 func TestToolResultFromLlmError(t *testing.T) {
-	result, err := toolResultFromLlmError("upstream failure", "UPSTREAM_ERROR")
+	result, err := toolResultFromLlmError("upstream failure", llmErrorCodeUpstreamError)
 
 	assert.NoError(t, err)
 	require.NotNil(t, result)

--- a/mcp/tools/package_insights.go
+++ b/mcp/tools/package_insights.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -67,7 +68,17 @@ func (t *packageInsightsTool) executeGetPackageVulnerabilities(ctx context.Conte
 
 	vulns, err := t.driver.GetPackageVersionVulnerabilities(ctx, parsedPurl.PackageVersion())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get package vulnerabilities: %w", err)
+		if errors.Is(err, mcp.ErrPackageVersionInsightNotFound) {
+			return toolResultFromLlmError(
+				fmt.Sprintf("no package insights found for package: %s", purl),
+				"PACKAGE_INSIGHT_NOT_FOUND",
+			)
+		}
+
+		return toolResultFromLlmError(
+			fmt.Sprintf("failed to get package vulnerabilities: %v", err),
+			"UPSTREAM_ERROR",
+		)
 	}
 
 	logger.Debugf("Found %d vulnerabilities for package: %s", len(vulns), purl)
@@ -97,7 +108,17 @@ func (t *packageInsightsTool) executeGetPackagePopularity(ctx context.Context,
 
 	popularity, err := t.driver.GetPackageVersionPopularity(ctx, parsedPurl.PackageVersion())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get package popularity: %w", err)
+		if errors.Is(err, mcp.ErrPackageVersionInsightNotFound) {
+			return toolResultFromLlmError(
+				fmt.Sprintf("no package insights found for package: %s", purl),
+				"PACKAGE_INSIGHT_NOT_FOUND",
+			)
+		}
+
+		return toolResultFromLlmError(
+			fmt.Sprintf("failed to get package popularity: %v", err),
+			"UPSTREAM_ERROR",
+		)
 	}
 
 	logger.Debugf("Found %d popularity for package: %s", len(popularity), purl)
@@ -127,11 +148,24 @@ func (t *packageInsightsTool) executeGetPackageLicenseInfo(ctx context.Context,
 
 	licenseInfo, err := t.driver.GetPackageVersionLicenseInfo(ctx, parsedPurl.PackageVersion())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get package license info: %w", err)
+		if errors.Is(err, mcp.ErrPackageVersionInsightNotFound) {
+			return toolResultFromLlmError(
+				fmt.Sprintf("no package insights found for package: %s", purl),
+				"PACKAGE_INSIGHT_NOT_FOUND",
+			)
+		}
+
+		return toolResultFromLlmError(
+			fmt.Sprintf("failed to get package license info: %v", err),
+			"UPSTREAM_ERROR",
+		)
 	}
 
 	if licenseInfo == nil {
-		return nil, fmt.Errorf("no license info returned for package: %s", purl)
+		return toolResultFromLlmError(
+			fmt.Sprintf("no license info returned for package: %s", purl),
+			"PACKAGE_INSIGHT_NOT_FOUND",
+		)
 	}
 
 	logger.Debugf("Found %d license info for package: %s", len(licenseInfo.Licenses), purl)

--- a/mcp/tools/package_insights.go
+++ b/mcp/tools/package_insights.go
@@ -71,13 +71,13 @@ func (t *packageInsightsTool) executeGetPackageVulnerabilities(ctx context.Conte
 		if errors.Is(err, mcp.ErrPackageVersionInsightNotFound) {
 			return toolResultFromLlmError(
 				fmt.Sprintf("no package insights found for package: %s", purl),
-				"PACKAGE_INSIGHT_NOT_FOUND",
+				llmErrorCodePackageInsightNotFound,
 			)
 		}
 
 		return toolResultFromLlmError(
 			fmt.Sprintf("failed to get package vulnerabilities: %v", err),
-			"UPSTREAM_ERROR",
+			llmErrorCodeUpstreamError,
 		)
 	}
 
@@ -111,13 +111,13 @@ func (t *packageInsightsTool) executeGetPackagePopularity(ctx context.Context,
 		if errors.Is(err, mcp.ErrPackageVersionInsightNotFound) {
 			return toolResultFromLlmError(
 				fmt.Sprintf("no package insights found for package: %s", purl),
-				"PACKAGE_INSIGHT_NOT_FOUND",
+				llmErrorCodePackageInsightNotFound,
 			)
 		}
 
 		return toolResultFromLlmError(
 			fmt.Sprintf("failed to get package popularity: %v", err),
-			"UPSTREAM_ERROR",
+			llmErrorCodeUpstreamError,
 		)
 	}
 
@@ -151,20 +151,20 @@ func (t *packageInsightsTool) executeGetPackageLicenseInfo(ctx context.Context,
 		if errors.Is(err, mcp.ErrPackageVersionInsightNotFound) {
 			return toolResultFromLlmError(
 				fmt.Sprintf("no package insights found for package: %s", purl),
-				"PACKAGE_INSIGHT_NOT_FOUND",
+				llmErrorCodePackageInsightNotFound,
 			)
 		}
 
 		return toolResultFromLlmError(
 			fmt.Sprintf("failed to get package license info: %v", err),
-			"UPSTREAM_ERROR",
+			llmErrorCodeUpstreamError,
 		)
 	}
 
 	if licenseInfo == nil {
 		return toolResultFromLlmError(
 			fmt.Sprintf("no license info returned for package: %s", purl),
-			"PACKAGE_INSIGHT_NOT_FOUND",
+			llmErrorCodePackageInsightNotFound,
 		)
 	}
 

--- a/mcp/tools/package_insights_test.go
+++ b/mcp/tools/package_insights_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
@@ -72,8 +73,8 @@ func TestPackageInsightsTool_ExecuteGetPackageVulnerabilities(t *testing.T) {
 				driver.On("GetPackageVersionVulnerabilities", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
 					Return(([]*vulnerabilityv1.Vulnerability)(nil), mcp.ErrPackageVersionInsightNotFound)
 			},
-			expectedContains: "",
-			expectedError:    "failed to get package vulnerabilities",
+			expectedContains: "PACKAGE_INSIGHT_NOT_FOUND",
+			expectedError:    "",
 		},
 		{
 			name: "driver returns other error",
@@ -84,8 +85,8 @@ func TestPackageInsightsTool_ExecuteGetPackageVulnerabilities(t *testing.T) {
 				driver.On("GetPackageVersionVulnerabilities", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
 					Return(([]*vulnerabilityv1.Vulnerability)(nil), errors.New("internal server error"))
 			},
-			expectedContains: "",
-			expectedError:    "failed to get package vulnerabilities",
+			expectedContains: "UPSTREAM_ERROR",
+			expectedError:    "",
 		},
 	}
 
@@ -181,6 +182,18 @@ func TestPackageInsightsTool_ExecuteGetPackagePopularity(t *testing.T) {
 			expectedError:    "invalid purl",
 		},
 		{
+			name: "driver returns wrapped insight not found error",
+			requestArgs: map[string]interface{}{
+				"purl": "pkg:npm/express@4.17.1",
+			},
+			setupDriver: func(driver *MockDriver) {
+				driver.On("GetPackageVersionPopularity", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
+					Return(([]*packagev1.ProjectInsight)(nil), fmt.Errorf("failed to get package version insight: %w", mcp.ErrPackageVersionInsightNotFound))
+			},
+			expectedContains: "PACKAGE_INSIGHT_NOT_FOUND",
+			expectedError:    "",
+		},
+		{
 			name: "driver returns error",
 			requestArgs: map[string]interface{}{
 				"purl": "pkg:npm/express@4.17.1",
@@ -189,8 +202,8 @@ func TestPackageInsightsTool_ExecuteGetPackagePopularity(t *testing.T) {
 				driver.On("GetPackageVersionPopularity", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
 					Return(([]*packagev1.ProjectInsight)(nil), errors.New("internal server error"))
 			},
-			expectedContains: "",
-			expectedError:    "failed to get package popularity",
+			expectedContains: "UPSTREAM_ERROR",
+			expectedError:    "",
 		},
 	}
 
@@ -292,8 +305,8 @@ func TestPackageInsightsTool_ExecuteGetPackageLicenseInfo(t *testing.T) {
 				driver.On("GetPackageVersionLicenseInfo", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
 					Return((*packagev1.LicenseMetaList)(nil), errors.New("internal server error"))
 			},
-			expectedContains: "",
-			expectedError:    "failed to get package license info",
+			expectedContains: "UPSTREAM_ERROR",
+			expectedError:    "",
 		},
 
 		{
@@ -305,8 +318,8 @@ func TestPackageInsightsTool_ExecuteGetPackageLicenseInfo(t *testing.T) {
 				driver.On("GetPackageVersionLicenseInfo", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
 					Return(nil, nil)
 			},
-			expectedContains: "",
-			expectedError:    "no license info returned for package",
+			expectedContains: "PACKAGE_INSIGHT_NOT_FOUND",
+			expectedError:    "",
 		},
 	}
 

--- a/mcp/tools/package_malware.go
+++ b/mcp/tools/package_malware.go
@@ -59,7 +59,7 @@ func (t *packageMalwareTool) executeCheckPackageMalware(ctx context.Context,
 
 		return toolResultFromLlmError(
 			fmt.Sprintf("failed to get package version malware report: %v", err),
-			"UPSTREAM_ERROR",
+			llmErrorCodeUpstreamError,
 		)
 	}
 

--- a/mcp/tools/package_malware.go
+++ b/mcp/tools/package_malware.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -52,12 +53,14 @@ func (t *packageMalwareTool) executeCheckPackageMalware(ctx context.Context,
 
 	malwareReport, err := t.driver.GetPackageVersionMalwareReport(ctx, parsedPurl.PackageVersion())
 	if err != nil {
-		// Handle this error gracefully otherwise LLMs will hallucinate
-		if err == mcp.ErrMaliciousPackageScanningPackageNotFound {
+		if errors.Is(err, mcp.ErrMaliciousPackageScanningPackageNotFound) {
 			return mcpgo.NewToolResultText("No known malware found for this package"), nil
 		}
 
-		return nil, fmt.Errorf("failed to get package version malware report: %w", err)
+		return toolResultFromLlmError(
+			fmt.Sprintf("failed to get package version malware report: %v", err),
+			"UPSTREAM_ERROR",
+		)
 	}
 
 	malwareReportJson, err := serializeForLlm(malwareReport)

--- a/mcp/tools/package_malware_test.go
+++ b/mcp/tools/package_malware_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	malysisv1pb "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/malysis/v1"
@@ -70,6 +71,18 @@ func TestPackageMalwareTool_ExecuteCheckPackageMalware(t *testing.T) {
 					Return((*malysisv1pb.Report)(nil), mcp.ErrMaliciousPackageScanningPackageNotFound)
 			},
 			expectedContains: "No known malware found for this package",
+			expectedError:    "",
+		},
+		{
+			name: "driver returns upstream error",
+			requestArgs: map[string]interface{}{
+				"purl": "pkg:npm/express@4.17.1",
+			},
+			setupDriver: func(driver *MockDriver) {
+				driver.On("GetPackageVersionMalwareReport", mock.Anything, mock.AnythingOfType("*packagev1.PackageVersion")).
+					Return((*malysisv1pb.Report)(nil), errors.New("upstream unavailable"))
+			},
+			expectedContains: "UPSTREAM_ERROR",
 			expectedError:    "",
 		},
 	}

--- a/mcp/tools/package_registry.go
+++ b/mcp/tools/package_registry.go
@@ -60,7 +60,7 @@ func (t *packageRegistryTool) executeGetPackageLatestVersion(ctx context.Context
 	if err != nil {
 		return toolResultFromLlmError(
 			fmt.Sprintf("failed to get package latest version: %v", err),
-			"UPSTREAM_ERROR",
+			llmErrorCodeUpstreamError,
 		)
 	}
 
@@ -91,7 +91,7 @@ func (t *packageRegistryTool) executeGetPackageAvailableVersions(ctx context.Con
 	if err != nil {
 		return toolResultFromLlmError(
 			fmt.Sprintf("failed to get package available versions: %v", err),
-			"UPSTREAM_ERROR",
+			llmErrorCodeUpstreamError,
 		)
 	}
 

--- a/mcp/tools/package_registry.go
+++ b/mcp/tools/package_registry.go
@@ -58,7 +58,10 @@ func (t *packageRegistryTool) executeGetPackageLatestVersion(ctx context.Context
 
 	latestVersion, err := t.driver.GetPackageLatestVersion(ctx, parsedPurl.PackageVersion().GetPackage())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get package latest version: %w", err)
+		return toolResultFromLlmError(
+			fmt.Sprintf("failed to get package latest version: %v", err),
+			"UPSTREAM_ERROR",
+		)
 	}
 
 	latestVersionJson, err := serializeForLlm(latestVersion)
@@ -86,7 +89,10 @@ func (t *packageRegistryTool) executeGetPackageAvailableVersions(ctx context.Con
 
 	availableVersions, err := t.driver.GetPackageAvailableVersions(ctx, parsedPurl.PackageVersion().GetPackage())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get package available versions: %w", err)
+		return toolResultFromLlmError(
+			fmt.Sprintf("failed to get package available versions: %v", err),
+			"UPSTREAM_ERROR",
+		)
 	}
 
 	availableVersionsJson, err := serializeForLlm(availableVersions)

--- a/mcp/tools/package_registry_test.go
+++ b/mcp/tools/package_registry_test.go
@@ -68,8 +68,8 @@ func TestPackageRegistryTool_ExecuteGetPackageLatestVersion(t *testing.T) {
 				driver.On("GetPackageLatestVersion", mock.Anything, mock.AnythingOfType("*packagev1.Package")).
 					Return((*packagev1.PackageVersion)(nil), errors.New("registry unavailable"))
 			},
-			expectedContains: "",
-			expectedError:    "failed to get package latest version",
+			expectedContains: "UPSTREAM_ERROR",
+			expectedError:    "",
 		},
 	}
 
@@ -179,8 +179,8 @@ func TestPackageRegistryTool_ExecuteGetPackageAvailableVersions(t *testing.T) {
 				driver.On("GetPackageAvailableVersions", mock.Anything, mock.AnythingOfType("*packagev1.Package")).
 					Return(([]*packagev1.PackageVersion)(nil), errors.New("registry unavailable"))
 			},
-			expectedContains: "",
-			expectedError:    "failed to get package available versions",
+			expectedContains: "UPSTREAM_ERROR",
+			expectedError:    "",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Return structured JSON tool results with `type: ERROR` when upstream package insights, vulnerability, malware, or registry lookups fail, instead of failing the MCP tool call with a Go error.

## Motivation

LLM clients cannot recover when MCP tool calls fail hard on expected upstream conditions such as missing package insights or transient API errors. Issue #541 requests graceful, machine-readable error payloads so agents can interpret failures and continue.

Fixes #541

## Changes

| File | Change |
|------|--------|
| `mcp/tools/common.go` | Add `llmErrorResponse`, `serializeErrorForLlm`, and `toolResultFromLlmError` helpers |
| `mcp/tools/package_insights.go` | Return `PACKAGE_INSIGHT_NOT_FOUND` / `UPSTREAM_ERROR` JSON for insight lookup failures |
| `mcp/tools/package_malware.go` | Return `UPSTREAM_ERROR` JSON for malware API failures (keep not-found success text) |
| `mcp/tools/package_registry.go` | Return `UPSTREAM_ERROR` JSON for registry failures |
| `mcp/tools/*_test.go` | Update/add tests for graceful error responses and wrapped sentinel errors |

## Tests

- `go test ./mcp/tools/... -count=1` — all passed
- Composer-2.5 review: APPROVE after `errors.Is` fix for wrapped driver errors

## Notes

- Input validation errors (missing/invalid purl) still return Go errors since those are client-side mistakes.
- Malware scan not-found continues to return the existing plain-text success message to avoid LLM hallucination.
