### PR TITLE
feat(xbom): refresh AI signatures for pypi, npm, and java

### DIFF
--- a/docs/xbom.md
+++ b/docs/xbom.md
@@ -72,11 +72,11 @@ The full list of flags is available via `vet code scan --help`, `vet code query 
 
 ## What Gets Detected
 
-Signatures cover three language ecosystems (**Go**, **Python**, **JavaScript/TypeScript**) across these categories:
+Signatures cover five languages (**Go**, **Python**, **JavaScript/TypeScript**, **Java**) across these categories:
 
 | Category | Examples |
 |----------|---------|
-| **AI/LLM** | OpenAI client, Anthropic (Claude, Bedrock, VertexAI), LangChain, CrewAI |
+| **AI/LLM** | OpenAI, Anthropic, Gemini, Grok, Mistral, Bedrock, LangChain, LangGraph, CrewAI, Vercel AI SDK, Spring AI, MCP SDKs |
 | **Cryptography** | AES/RSA encryption, SHA/MD5 hashing, key derivation |
 | **Cloud** | GCP Pub/Sub, Azure Service Bus, Azure AI, Microsoft Office integrations |
 | **Network** | HTTP client/server, TCP/UDP sockets, DNS lookups |
@@ -154,6 +154,11 @@ signatures/
 │   └── ai/
 ├── langchain/
 ├── crewai/
+├── xai/                     #   Grok SDK
+├── vercel/                  #   AI SDK (npm `ai`)
+├── modelcontextprotocol/    #   MCP SDKs
+├── aws/                     #   Bedrock, Strands Agents
+├── spring/                  #   Spring AI (Java)
 ├── google/
 │   └── gcp/
 ├── microsoft/

--- a/docs/xbom.md
+++ b/docs/xbom.md
@@ -72,7 +72,7 @@ The full list of flags is available via `vet code scan --help`, `vet code query 
 
 ## What Gets Detected
 
-Signatures cover five languages (**Go**, **Python**, **JavaScript/TypeScript**, **Java**) across these categories:
+Signatures cover five languages (**Go**, **Python**, **JavaScript**, **TypeScript**, **Java**) across these categories:
 
 | Category | Examples |
 |----------|---------|

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -42,6 +42,7 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"Cryptography signatures", "cryptography", "", "", 1},
 		{"LangChain signatures", "langchain", "", "", 1},
 		{"CrewAI signatures", "crewai", "", "", 1},
+		{"AWS signatures", "aws", "", "", 1},
 	}
 
 	for _, tc := range cases {

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -49,6 +49,10 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"Cohere signatures", "cohere", "", "", 1},
 		{"Groq signatures", "groq", "", "", 1},
 		{"Ollama signatures", "ollama", "", "", 1},
+		{"Hugging Face signatures", "huggingface", "", "", 1},
+		{"Together AI signatures", "togetherai", "", "", 1},
+		{"Fireworks signatures", "fireworks", "", "", 1},
+		{"Perplexity signatures", "perplexity", "", "", 1},
 	}
 
 	for _, tc := range cases {

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -53,6 +53,8 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"Together AI signatures", "togetherai", "", "", 1},
 		{"Fireworks signatures", "fireworks", "", "", 1},
 		{"Perplexity signatures", "perplexity", "", "", 1},
+		{"Vercel signatures", "vercel", "", "", 1},
+		{"Pydantic AI signatures", "pydantic", "", "", 1},
 	}
 
 	for _, tc := range cases {

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -55,6 +55,8 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"Perplexity signatures", "perplexity", "", "", 1},
 		{"Vercel signatures", "vercel", "", "", 1},
 		{"Pydantic AI signatures", "pydantic", "", "", 1},
+		{"LlamaIndex signatures", "llamaindex", "", "", 1},
+		{"Mastra signatures", "mastra", "", "", 1},
 	}
 
 	for _, tc := range cases {

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -43,6 +43,7 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"LangChain signatures", "langchain", "", "", 1},
 		{"CrewAI signatures", "crewai", "", "", 1},
 		{"AWS signatures", "aws", "", "", 1},
+		{"MCP signatures", "modelcontextprotocol", "", "", 2},
 	}
 
 	for _, tc := range cases {

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -38,6 +38,7 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"OpenAI signatures", "openai", "", "", 1},
 		{"Anthropic signatures", "anthropic", "", "", 1},
 		{"Google GCP signatures", "google", "", "", 1},
+		{"xAI signatures", "xai", "", "", 1},
 		{"Microsoft signatures", "microsoft", "", "", 1},
 		{"Cryptography signatures", "cryptography", "", "", 1},
 		{"LangChain signatures", "langchain", "", "", 1},

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -58,6 +58,9 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"LlamaIndex signatures", "llamaindex", "", "", 1},
 		{"Mastra signatures", "mastra", "", "", 1},
 		{"Spring AI signatures", "spring", "", "", 1},
+		{"Alibaba signatures", "alibaba", "", "", 1},
+		{"Deepset signatures", "deepset", "", "", 1},
+		{"Agno signatures", "agno", "", "", 1},
 	}
 
 	for _, tc := range cases {

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -57,6 +57,7 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"Pydantic AI signatures", "pydantic", "", "", 1},
 		{"LlamaIndex signatures", "llamaindex", "", "", 1},
 		{"Mastra signatures", "mastra", "", "", 1},
+		{"Spring AI signatures", "spring", "", "", 1},
 	}
 
 	for _, tc := range cases {

--- a/pkg/xbom/signatures/signatures_test.go
+++ b/pkg/xbom/signatures/signatures_test.go
@@ -45,6 +45,10 @@ func TestLoadSignaturesByVendor(t *testing.T) {
 		{"CrewAI signatures", "crewai", "", "", 1},
 		{"AWS signatures", "aws", "", "", 1},
 		{"MCP signatures", "modelcontextprotocol", "", "", 2},
+		{"Mistral signatures", "mistralai", "", "", 1},
+		{"Cohere signatures", "cohere", "", "", 1},
+		{"Groq signatures", "groq", "", "", 1},
+		{"Ollama signatures", "ollama", "", "", 1},
 	}
 
 	for _, tc := range cases {

--- a/signatures/agno/ai/agents.yaml
+++ b/signatures/agno/ai/agents.yaml
@@ -1,0 +1,21 @@
+version: 0.1
+# References -
+# https://pypi.org/project/agno/
+
+signatures:
+  - id: agno.agent
+    description: "Agno agent framework (formerly Phidata)"
+    vendor: "Agno"
+    product: "Agno"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "agno.agent.Agent"
+          - type: call
+            value: "agno.team.Team"
+          - type: call
+            value: "agno.workflow.Workflow"

--- a/signatures/alibaba/dashscope/llm.yaml
+++ b/signatures/alibaba/dashscope/llm.yaml
@@ -1,0 +1,27 @@
+version: 0.1
+# References -
+# https://pypi.org/project/dashscope/
+# https://central.sonatype.com/artifact/com.alibaba/dashscope-sdk-java
+
+signatures:
+  - id: alibaba.dashscope.llm
+    description: "Alibaba DashScope (Qwen) model client"
+    vendor: "Alibaba"
+    product: "DashScope"
+    service: "AI model client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "dashscope.Generation.call"
+          - type: call
+            value: "dashscope.MultiModalConversation.call"
+          - type: call
+            value: "dashscope.TextEmbedding.call"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "com.alibaba.dashscope.*"

--- a/signatures/anthropic/agents/sdk.yaml
+++ b/signatures/anthropic/agents/sdk.yaml
@@ -1,0 +1,33 @@
+version: 0.1
+# References -
+# https://pypi.org/project/claude-agent-sdk/
+# https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk
+
+signatures:
+  - id: anthropic.agents.sdk
+    description: "Claude Agent SDK"
+    vendor: "Anthropic"
+    product: "Claude Agent SDK"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "claude_agent_sdk.query"
+          - type: call
+            value: "claude_agent_sdk.ClaudeSDKClient"
+          - type: call
+            value: "claude_agent_sdk.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@anthropic-ai/claude-agent-sdk/query"
+          - type: call
+            value: "@anthropic-ai/claude-agent-sdk/tool"
+          - type: call
+            value: "@anthropic-ai/claude-agent-sdk/createSdkMcpServer"
+          - type: call
+            value: "@anthropic-ai/claude-agent-sdk/*"

--- a/signatures/anthropic/ai/llm.yaml
+++ b/signatures/anthropic/ai/llm.yaml
@@ -4,6 +4,7 @@ version: 0.1
 # https://github.com/anthropics/anthropic-sdk-java
 # https://javadoc.io/doc/com.anthropic/anthropic-java/latest/index.html
 # https://github.com/anthropics/anthropic-sdk-go
+# https://www.npmjs.com/package/@anthropic-ai/sdk
 
 signatures:
   - id: anthropic.client
@@ -18,6 +19,13 @@ signatures:
         conditions:
           - type: call
             value: "anthropic.Anthropic"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@anthropic-ai/sdk/Anthropic"
+          - type: call
+            value: "@anthropic-ai/sdk/*"
       java:
         match: any
         conditions:
@@ -84,6 +92,11 @@ signatures:
         conditions:
           - type: call
             value: "anthropic.AnthropicBedrock"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@anthropic-ai/bedrock-sdk/AnthropicBedrock"
       java:
         match: any
         conditions:
@@ -104,6 +117,11 @@ signatures:
             value: "anthropic.AnthropicVertex"
           - type: call
             value: "anthropic.AsyncAnthropicVertex"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@anthropic-ai/vertex-sdk/AnthropicVertex"
       java:
         match: any
         conditions:

--- a/signatures/anthropic/ai/llm.yaml
+++ b/signatures/anthropic/ai/llm.yaml
@@ -23,6 +23,8 @@ signatures:
         match: any
         conditions:
           - type: call
+            value: "@anthropic-ai/sdk"
+          - type: call
             value: "@anthropic-ai/sdk/Anthropic"
           - type: call
             value: "@anthropic-ai/sdk/*"
@@ -96,6 +98,8 @@ signatures:
         match: any
         conditions:
           - type: call
+            value: "@anthropic-ai/bedrock-sdk"
+          - type: call
             value: "@anthropic-ai/bedrock-sdk/AnthropicBedrock"
       java:
         match: any
@@ -120,6 +124,8 @@ signatures:
       javascript:
         match: any
         conditions:
+          - type: call
+            value: "@anthropic-ai/vertex-sdk"
           - type: call
             value: "@anthropic-ai/vertex-sdk/AnthropicVertex"
       java:

--- a/signatures/aws/bedrock/runtime.yaml
+++ b/signatures/aws/bedrock/runtime.yaml
@@ -1,0 +1,42 @@
+version: 0.1
+# References -
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime.html
+# https://www.npmjs.com/package/@aws-sdk/client-bedrock-runtime
+# https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/bedrockruntime/package-summary.html
+
+signatures:
+  - id: aws.bedrock.runtime
+    description: "AWS Bedrock runtime client for foundation model inference"
+    vendor: "AWS"
+    product: "Amazon Bedrock"
+    service: "AI model inference"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "boto3.client"
+            args:
+              - index: 0
+                values: ['"bedrock-runtime"', "'bedrock-runtime'"]
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@aws-sdk/client-bedrock-runtime.BedrockRuntimeClient"
+          - type: call
+            value: "@aws-sdk/client-bedrock-runtime.InvokeModelCommand"
+          - type: call
+            value: "@aws-sdk/client-bedrock-runtime.ConverseCommand"
+          - type: call
+            value: "@aws-sdk/client-bedrock-runtime.ConverseStreamCommand"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient.builder"
+          - type: call
+            value: "software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient.create"
+          - type: call
+            value: "software.amazon.awssdk.services.bedrockruntime.*"

--- a/signatures/aws/bedrock/runtime.yaml
+++ b/signatures/aws/bedrock/runtime.yaml
@@ -24,13 +24,13 @@ signatures:
         match: any
         conditions:
           - type: call
-            value: "@aws-sdk/client-bedrock-runtime.BedrockRuntimeClient"
+            value: "@aws-sdk/client-bedrock-runtime/BedrockRuntimeClient"
           - type: call
-            value: "@aws-sdk/client-bedrock-runtime.InvokeModelCommand"
+            value: "@aws-sdk/client-bedrock-runtime/InvokeModelCommand"
           - type: call
-            value: "@aws-sdk/client-bedrock-runtime.ConverseCommand"
+            value: "@aws-sdk/client-bedrock-runtime/ConverseCommand"
           - type: call
-            value: "@aws-sdk/client-bedrock-runtime.ConverseStreamCommand"
+            value: "@aws-sdk/client-bedrock-runtime/ConverseStreamCommand"
       java:
         match: any
         conditions:

--- a/signatures/aws/strands/agents.yaml
+++ b/signatures/aws/strands/agents.yaml
@@ -1,0 +1,27 @@
+version: 0.1
+# References -
+# https://pypi.org/project/strands-agents/ (imports as `strands`)
+# https://www.npmjs.com/package/@strands-agents/sdk
+
+signatures:
+  - id: aws.strands.agent
+    description: "AWS Strands Agents SDK"
+    vendor: "AWS"
+    product: "Strands Agents"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "strands.Agent"
+          - type: call
+            value: "strands.tool"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@strands-agents/sdk/Agent"
+          - type: call
+            value: "@strands-agents/sdk/*"

--- a/signatures/cohere/ai/llm.yaml
+++ b/signatures/cohere/ai/llm.yaml
@@ -1,0 +1,37 @@
+version: 0.1
+# References -
+# https://pypi.org/project/cohere/
+# https://www.npmjs.com/package/cohere-ai
+# https://central.sonatype.com/artifact/com.cohere/cohere-java
+
+signatures:
+  - id: cohere.client
+    description: "Cohere API client"
+    vendor: "Cohere"
+    product: "Cohere API"
+    service: "AI client"
+    tags: [ai, llm, text, embeddings]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "cohere.ClientV2"
+          - type: call
+            value: "cohere.Client"
+          - type: call
+            value: "cohere.AsyncClientV2"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "cohere-ai/CohereClientV2"
+          - type: call
+            value: "cohere-ai/CohereClient"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "com.cohere.api.Cohere.builder"
+          - type: call
+            value: "com.cohere.api.*"

--- a/signatures/deepset/haystack/ai.yaml
+++ b/signatures/deepset/haystack/ai.yaml
@@ -1,0 +1,19 @@
+version: 0.1
+# References -
+# https://pypi.org/project/haystack-ai/ (imports as `haystack`)
+
+signatures:
+  - id: deepset.haystack.pipeline
+    description: "Haystack AI pipeline and agent framework"
+    vendor: "deepset"
+    product: "Haystack"
+    service: "AI pipeline"
+    tags: [ai, llm, agent]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "haystack.Pipeline"
+          - type: call
+            value: "haystack.components.agents.Agent"

--- a/signatures/fireworks/ai/llm.yaml
+++ b/signatures/fireworks/ai/llm.yaml
@@ -1,0 +1,19 @@
+version: 0.1
+# References -
+# https://pypi.org/project/fireworks-ai/ (imports as `fireworks`)
+
+signatures:
+  - id: fireworks.client
+    description: "Fireworks AI API client"
+    vendor: "Fireworks AI"
+    product: "Fireworks API"
+    service: "AI client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "fireworks.Fireworks"
+          - type: call
+            value: "fireworks.AsyncFireworks"

--- a/signatures/fireworks/ai/llm.yaml
+++ b/signatures/fireworks/ai/llm.yaml
@@ -17,3 +17,7 @@ signatures:
             value: "fireworks.Fireworks"
           - type: call
             value: "fireworks.AsyncFireworks"
+          - type: call
+            value: "fireworks.client.Fireworks"
+          - type: call
+            value: "fireworks.client.AsyncFireworks"

--- a/signatures/google/adk/agents.yaml
+++ b/signatures/google/adk/agents.yaml
@@ -1,0 +1,29 @@
+version: 0.1
+# References -
+# https://pypi.org/project/google-adk/
+# https://central.sonatype.com/artifact/com.google.adk/google-adk
+
+signatures:
+  - id: google.adk.agent
+    description: "Google Agent Development Kit"
+    vendor: "Google"
+    product: "ADK"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "google.adk.Agent"
+          - type: call
+            value: "google.adk.runners.Runner"
+          - type: call
+            value: "google.adk.*"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "com.google.adk.agents.LlmAgent.builder"
+          - type: call
+            value: "com.google.adk.*"

--- a/signatures/google/genai/llm.yaml
+++ b/signatures/google/genai/llm.yaml
@@ -1,0 +1,52 @@
+version: 0.1
+# References -
+# https://pypi.org/project/google-genai/
+# https://www.npmjs.com/package/@google/genai
+# https://central.sonatype.com/artifact/com.google.genai/google-genai
+
+signatures:
+  - id: google.genai.client
+    description: "Google Gemini API client (google-genai SDK)"
+    vendor: "Google"
+    product: "Gemini"
+    service: "AI client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "google.genai.Client"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@google/genai/GoogleGenAI"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "com.google.genai.Client.builder"
+
+  - id: google.genai.sdk
+    description: "Google Gemini SDK API surfaces (models, chats, embeddings)"
+    vendor: "Google"
+    product: "Gemini"
+    service: "AI model operations"
+    tags: [ai, llm, text, embeddings]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "google.genai.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@google/genai/*"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "com.google.genai.*"

--- a/signatures/groq/ai/llm.yaml
+++ b/signatures/groq/ai/llm.yaml
@@ -23,3 +23,7 @@ signatures:
         conditions:
           - type: call
             value: "groq-sdk"
+          - type: call
+            value: "groq-sdk/Groq"
+          - type: call
+            value: "groq-sdk/*"

--- a/signatures/groq/ai/llm.yaml
+++ b/signatures/groq/ai/llm.yaml
@@ -1,0 +1,25 @@
+version: 0.1
+# References -
+# https://pypi.org/project/groq/
+# https://www.npmjs.com/package/groq-sdk
+
+signatures:
+  - id: groq.client
+    description: "Groq API client for fast LLM inference"
+    vendor: "Groq"
+    product: "Groq API"
+    service: "AI client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "groq.Groq"
+          - type: call
+            value: "groq.AsyncGroq"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "groq-sdk"

--- a/signatures/huggingface/inference/llm.yaml
+++ b/signatures/huggingface/inference/llm.yaml
@@ -1,0 +1,27 @@
+version: 0.1
+# References -
+# https://pypi.org/project/huggingface-hub/
+# https://www.npmjs.com/package/@huggingface/inference
+
+signatures:
+  - id: huggingface.inference.client
+    description: "Hugging Face inference client"
+    vendor: "Hugging Face"
+    product: "Inference"
+    service: "AI inference client"
+    tags: [ai, llm, ml, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "huggingface_hub.InferenceClient"
+          - type: call
+            value: "huggingface_hub.AsyncInferenceClient"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@huggingface/inference/InferenceClient"
+          - type: call
+            value: "@huggingface/inference/HfInference"

--- a/signatures/huggingface/smolagents/agents.yaml
+++ b/signatures/huggingface/smolagents/agents.yaml
@@ -1,0 +1,19 @@
+version: 0.1
+# References -
+# https://pypi.org/project/smolagents/
+
+signatures:
+  - id: huggingface.smolagents.agent
+    description: "Hugging Face smolagents framework"
+    vendor: "Hugging Face"
+    product: "smolagents"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "smolagents.CodeAgent"
+          - type: call
+            value: "smolagents.ToolCallingAgent"

--- a/signatures/langchain/langchain/community.yaml
+++ b/signatures/langchain/langchain/community.yaml
@@ -382,5 +382,3 @@ signatures:
         conditions:
           - type: call
             value: "@langchain/community/*"
-
-

--- a/signatures/langchain/langchain/community.yaml
+++ b/signatures/langchain/langchain/community.yaml
@@ -120,11 +120,6 @@ signatures:
         conditions:
           - type: call
             value: "langchain_community.chat_models.*"
-      javascript:
-        match: any
-        conditions:
-          - type: call
-            value: "@langchain/community/*"
 
   - id: langchain_community.cross_encoders
     description: "Cross encoders are wrappers around cross encoder models from different APIs and services."
@@ -374,5 +369,18 @@ signatures:
         conditions:
           - type: call
             value: "langchain_community.vectorstores.*"
+
+  - id: langchain.community.js
+    description: "LangChain.js community integrations"
+    vendor: "LangChain"
+    product: "LangChain.js"
+    service: "Community integrations"
+    tags: [ai, llm]
+    languages:
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@langchain/community/*"
 
 

--- a/signatures/langchain/langchain/community.yaml
+++ b/signatures/langchain/langchain/community.yaml
@@ -120,6 +120,11 @@ signatures:
         conditions:
           - type: call
             value: "langchain_community.chat_models.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@langchain/community/*"
 
   - id: langchain_community.cross_encoders
     description: "Cross encoders are wrappers around cross encoder models from different APIs and services."

--- a/signatures/langchain/langchain/core.yaml
+++ b/signatures/langchain/langchain/core.yaml
@@ -146,11 +146,6 @@ signatures:
         conditions:
           - type: call
             value: "langchain_core.language_models.*"
-      javascript:
-        match: any
-        conditions:
-          - type: call
-            value: "@langchain/core/*"
 
   - id: langchain_core.load
     description: "Load module helps with serialization and deserialization."
@@ -372,3 +367,16 @@ signatures:
         conditions:
           - type: call
             value: "langchain_core.vectorstores.*"
+
+  - id: langchain.core.js
+    description: "LangChain.js core framework primitives"
+    vendor: "LangChain"
+    product: "LangChain.js"
+    service: "Core framework"
+    tags: [ai, llm]
+    languages:
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@langchain/core/*"

--- a/signatures/langchain/langchain/core.yaml
+++ b/signatures/langchain/langchain/core.yaml
@@ -146,6 +146,11 @@ signatures:
         conditions:
           - type: call
             value: "langchain_core.language_models.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@langchain/core/*"
 
   - id: langchain_core.load
     description: "Load module helps with serialization and deserialization."

--- a/signatures/langchain/langchain/langchain.yaml
+++ b/signatures/langchain/langchain/langchain.yaml
@@ -17,11 +17,22 @@ signatures:
         conditions:
           - type: call
             value: "langchain.agents.*"
+          - type: call
+            value: "langchain.agents.create_agent"
+          - type: call
+            value: "langchain.chat_models.init_chat_model"
       java:
         match: any
         conditions:
           - type: call
             value: "dev.langchain4j.agent.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "langchain/createAgent"
+          - type: call
+            value: "langchain/*"
 
   - id: langchain.mcp
     description: "Model Context Protocol support in Langchain"
@@ -339,3 +350,31 @@ signatures:
         conditions:
           - type: call
             value: "dev.langchain4j.data.video.*"
+
+  - id: langchain.providers.openai
+    description: "LangChain.js OpenAI provider package"
+    vendor: "LangChain"
+    product: "LangChain.js"
+    service: "OpenAI integration"
+    tags: [ai, llm, text]
+    languages:
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@langchain/openai/ChatOpenAI"
+          - type: call
+            value: "@langchain/openai/*"
+
+  - id: langchain.providers.anthropic
+    description: "LangChain.js Anthropic provider package"
+    vendor: "LangChain"
+    product: "LangChain.js"
+    service: "Anthropic integration"
+    tags: [ai, llm, text]
+    languages:
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@langchain/anthropic/*"

--- a/signatures/langchain/langchain/langchain.yaml
+++ b/signatures/langchain/langchain/langchain.yaml
@@ -19,8 +19,6 @@ signatures:
             value: "langchain.agents.*"
           - type: call
             value: "langchain.agents.create_agent"
-          - type: call
-            value: "langchain.chat_models.init_chat_model"
       java:
         match: any
         conditions:

--- a/signatures/langchain/langgraph/graph.yaml
+++ b/signatures/langchain/langgraph/graph.yaml
@@ -1,0 +1,27 @@
+version: 0.1
+# References -
+# https://pypi.org/project/langgraph/
+# https://www.npmjs.com/package/@langchain/langgraph
+
+signatures:
+  - id: langchain.langgraph.graph
+    description: "LangGraph stateful agent graph construction"
+    vendor: "LangChain"
+    product: "LangGraph"
+    service: "Agent orchestration"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "langgraph.graph.StateGraph"
+          - type: call
+            value: "langgraph.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@langchain/langgraph/StateGraph"
+          - type: call
+            value: "@langchain/langgraph/*"

--- a/signatures/llamaindex/ai/core.yaml
+++ b/signatures/llamaindex/ai/core.yaml
@@ -1,0 +1,35 @@
+version: 0.1
+# References -
+# https://pypi.org/project/llama-index/ (imports as `llama_index`)
+# https://www.npmjs.com/package/llamaindex
+
+signatures:
+  - id: llamaindex.core
+    description: "LlamaIndex data framework and agent workflow"
+    vendor: "LlamaIndex"
+    product: "LlamaIndex"
+    service: "AI data framework"
+    tags: [ai, llm, agent, embeddings]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "llama_index.core.VectorStoreIndex.from_documents"
+          - type: call
+            value: "llama_index.core.SimpleDirectoryReader"
+          - type: call
+            value: "llama_index.core.agent.workflow.FunctionAgent"
+          - type: call
+            value: "llama_index.core.agent.workflow.ReActAgent"
+          - type: call
+            value: "llama_index.core.agent.workflow.AgentWorkflow"
+          - type: call
+            value: "llama_index.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "llamaindex/*"
+          - type: call
+            value: "@llamaindex/workflow/agent"

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity vercel pydantic
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity vercel pydantic llamaindex mastra
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity vercel pydantic llamaindex mastra
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity vercel pydantic llamaindex mastra spring
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity vercel pydantic llamaindex mastra spring
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity vercel pydantic llamaindex mastra spring alibaba deepset agno
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama huggingface togetherai fireworks perplexity vercel pydantic
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/loader.go
+++ b/signatures/loader.go
@@ -6,7 +6,7 @@ import (
 	pkgsignatures "github.com/safedep/vet/pkg/xbom/signatures"
 )
 
-//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai
+//go:embed lang openai anthropic langchain crewai google microsoft cryptography github aws modelcontextprotocol xai mistralai cohere groq ollama
 var embeddedSignatureFS embed.FS
 
 func init() {

--- a/signatures/mastra/ai/agents.yaml
+++ b/signatures/mastra/ai/agents.yaml
@@ -1,0 +1,17 @@
+version: 0.1
+# References -
+# https://www.npmjs.com/package/@mastra/core
+
+signatures:
+  - id: mastra.agents
+    description: "Mastra TypeScript agent framework"
+    vendor: "Mastra"
+    product: "Mastra"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@mastra/core/*"

--- a/signatures/microsoft/agent-framework/agents.yaml
+++ b/signatures/microsoft/agent-framework/agents.yaml
@@ -16,4 +16,6 @@ signatures:
           - type: call
             value: "agent_framework.Agent"
           - type: call
+            value: "agent_framework.ChatAgent"
+          - type: call
             value: "agent_framework.openai.OpenAIChatClient"

--- a/signatures/microsoft/agent-framework/agents.yaml
+++ b/signatures/microsoft/agent-framework/agents.yaml
@@ -1,0 +1,19 @@
+version: 0.1
+# References -
+# https://pypi.org/project/agent-framework/ (imports as `agent_framework`)
+
+signatures:
+  - id: microsoft.agentframework.agent
+    description: "Microsoft Agent Framework (successor to Semantic Kernel and AutoGen)"
+    vendor: "Microsoft"
+    product: "Agent Framework"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "agent_framework.Agent"
+          - type: call
+            value: "agent_framework.openai.OpenAIChatClient"

--- a/signatures/microsoft/azure/ai.yaml
+++ b/signatures/microsoft/azure/ai.yaml
@@ -23,6 +23,8 @@ signatures:
         match: any
         conditions:
           - type: call
+            value: "@azure-rest/ai-vision-image-analysis"
+          - type: call
             value: "@azure-rest/ai-vision-image-analysis/*"
 
   - id: azure.translator
@@ -40,5 +42,7 @@ signatures:
       javascript:
         match: any
         conditions:
+          - type: call
+            value: "@azure-rest/ai-translation-text"
           - type: call
             value: "@azure-rest/ai-translation-text/*"

--- a/signatures/microsoft/azure/ai.yaml
+++ b/signatures/microsoft/azure/ai.yaml
@@ -23,7 +23,7 @@ signatures:
         match: any
         conditions:
           - type: call
-            value: "@azure-rest/ai-vision-image-analysis.*"
+            value: "@azure-rest/ai-vision-image-analysis/*"
 
   - id: azure.translator
     description: "Azure Text Translator"
@@ -41,4 +41,4 @@ signatures:
         match: any
         conditions:
           - type: call
-            value: "@azure-rest/ai-translation-text.*"
+            value: "@azure-rest/ai-translation-text/*"

--- a/signatures/microsoft/semantic-kernel/ai.yaml
+++ b/signatures/microsoft/semantic-kernel/ai.yaml
@@ -1,0 +1,25 @@
+version: 0.1
+# References -
+# https://pypi.org/project/semantic-kernel/
+# https://central.sonatype.com/artifact/com.microsoft.semantic-kernel/semantickernel-api
+
+signatures:
+  - id: microsoft.semantickernel.core
+    description: "Microsoft Semantic Kernel"
+    vendor: "Microsoft"
+    product: "Semantic Kernel"
+    service: "AI orchestration"
+    tags: [ai, llm, agent]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "semantic_kernel.Kernel"
+          - type: call
+            value: "semantic_kernel.agents.ChatCompletionAgent"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "com.microsoft.semantickernel.Kernel.*"

--- a/signatures/mistralai/ai/llm.yaml
+++ b/signatures/mistralai/ai/llm.yaml
@@ -1,0 +1,29 @@
+version: 0.1
+# References -
+# https://pypi.org/project/mistralai/
+# https://www.npmjs.com/package/@mistralai/mistralai
+
+signatures:
+  - id: mistralai.client
+    description: "Mistral AI API client"
+    vendor: "Mistral AI"
+    product: "Mistral API"
+    service: "AI client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "mistralai.client.Mistral"
+          - type: call
+            value: "mistralai.Mistral"
+          - type: call
+            value: "mistralai.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@mistralai/mistralai/Mistral"
+          - type: call
+            value: "@mistralai/mistralai/*"

--- a/signatures/modelcontextprotocol/sdk/mcp.yaml
+++ b/signatures/modelcontextprotocol/sdk/mcp.yaml
@@ -1,0 +1,60 @@
+version: 0.1
+# References -
+# https://pypi.org/project/mcp/
+# https://www.npmjs.com/package/@modelcontextprotocol/sdk
+# https://central.sonatype.com/artifact/io.modelcontextprotocol.sdk/mcp
+
+signatures:
+  - id: mcp.sdk.server
+    description: "Model Context Protocol server: exposes tools and resources to AI agents"
+    vendor: "Model Context Protocol"
+    product: "MCP SDK"
+    service: "MCP server"
+    tags: [ai, mcp, agent]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "mcp.server.fastmcp.FastMCP"
+          - type: call
+            value: "mcp.server.MCPServer"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@modelcontextprotocol/sdk/server/mcp.js/McpServer"
+          - type: call
+            value: "@modelcontextprotocol/server/McpServer"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "io.modelcontextprotocol.server.McpServer.*"
+
+  - id: mcp.sdk.client
+    description: "Model Context Protocol client: connects an application to MCP servers"
+    vendor: "Model Context Protocol"
+    product: "MCP SDK"
+    service: "MCP client"
+    tags: [ai, mcp, agent]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "mcp.Client"
+          - type: call
+            value: "mcp.ClientSession"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@modelcontextprotocol/sdk/client/index.js/Client"
+          - type: call
+            value: "@modelcontextprotocol/client/*"
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "io.modelcontextprotocol.client.*"

--- a/signatures/modelcontextprotocol/sdk/mcp.yaml
+++ b/signatures/modelcontextprotocol/sdk/mcp.yaml
@@ -24,6 +24,7 @@ signatures:
         conditions:
           - type: call
             value: "@modelcontextprotocol/sdk/server/mcp.js/McpServer"
+          # Unverified: speculative alternate package layout
           - type: call
             value: "@modelcontextprotocol/server/McpServer"
       java:
@@ -51,6 +52,7 @@ signatures:
         conditions:
           - type: call
             value: "@modelcontextprotocol/sdk/client/index.js/Client"
+          # Unverified: speculative alternate package layout
           - type: call
             value: "@modelcontextprotocol/client/*"
       java:

--- a/signatures/modelcontextprotocol/sdk/mcp.yaml
+++ b/signatures/modelcontextprotocol/sdk/mcp.yaml
@@ -24,6 +24,8 @@ signatures:
         conditions:
           - type: call
             value: "@modelcontextprotocol/sdk/server/mcp.js/McpServer"
+          - type: call
+            value: "@modelcontextprotocol/sdk/server/index.js/Server"
           # Unverified: speculative alternate package layout
           - type: call
             value: "@modelcontextprotocol/server/McpServer"

--- a/signatures/ollama/ai/llm.yaml
+++ b/signatures/ollama/ai/llm.yaml
@@ -1,0 +1,33 @@
+version: 0.1
+# References -
+# https://pypi.org/project/ollama/
+# https://www.npmjs.com/package/ollama
+
+signatures:
+  - id: ollama.client
+    description: "Ollama local LLM client"
+    vendor: "Ollama"
+    product: "Ollama"
+    service: "Local AI inference"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "ollama.chat"
+          - type: call
+            value: "ollama.generate"
+          - type: call
+            value: "ollama.embed"
+          - type: call
+            value: "ollama.Client"
+          - type: call
+            value: "ollama.AsyncClient"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "ollama/Ollama"
+          - type: call
+            value: "ollama/*"

--- a/signatures/openai/agents/agents.yaml
+++ b/signatures/openai/agents/agents.yaml
@@ -1,0 +1,33 @@
+version: 0.1
+# References -
+# https://pypi.org/project/openai-agents/ (imports as `agents`)
+# https://www.npmjs.com/package/@openai/agents
+
+signatures:
+  - id: openai.agents.sdk
+    description: "OpenAI Agents SDK"
+    vendor: "OpenAI"
+    product: "Agents SDK"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "agents.Agent"
+          - type: call
+            value: "agents.Runner.run"
+          - type: call
+            value: "agents.Runner.run_sync"
+          - type: call
+            value: "agents.function_tool"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@openai/agents/Agent"
+          - type: call
+            value: "@openai/agents/run"
+          - type: call
+            value: "@openai/agents/*"

--- a/signatures/openai/agents/agents.yaml
+++ b/signatures/openai/agents/agents.yaml
@@ -13,6 +13,10 @@ signatures:
     languages:
       python:
         match: any
+        # WARNING: the module name `agents` is generic and the engine cannot
+        # tell a local agents.py from the openai-agents package. Only these
+        # narrow, exact-symbol conditions keep this signature false-positive
+        # free. Never add a bare `agents.*` wildcard here.
         conditions:
           - type: call
             value: "agents.Agent"

--- a/signatures/openai/llm/ai.yaml
+++ b/signatures/openai/llm/ai.yaml
@@ -4,6 +4,7 @@ version: 0.1
 # https://github.com/openai/openai-java
 # https://github.com/openai/openai-go
 # https://learn.microsoft.com/en-us/java/api/overview/azure/ai-openai-readme?view=azure-java-preview
+# https://www.npmjs.com/package/openai
 
 signatures:
   - id: openai.client
@@ -18,6 +19,13 @@ signatures:
         conditions:
           - type: call
             value: "openai.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "openai/OpenAI"
+          - type: call
+            value: "openai/*"
       java:
         match: any
         conditions:
@@ -98,6 +106,11 @@ signatures:
         conditions:
           - type: call
             value: "openai.AzureOpenAI"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "openai/AzureOpenAI"
       java:
         match: any
         conditions:

--- a/signatures/openai/llm/ai.yaml
+++ b/signatures/openai/llm/ai.yaml
@@ -23,6 +23,8 @@ signatures:
         match: any
         conditions:
           - type: call
+            value: "openai"
+          - type: call
             value: "openai/OpenAI"
           - type: call
             value: "openai/*"

--- a/signatures/perplexity/ai/llm.yaml
+++ b/signatures/perplexity/ai/llm.yaml
@@ -1,0 +1,29 @@
+version: 0.1
+# References -
+# https://pypi.org/project/perplexityai/ (imports as `perplexity`)
+# https://www.npmjs.com/package/@perplexity-ai/perplexity_ai
+
+signatures:
+  - id: perplexity.client
+    description: "Perplexity API client"
+    vendor: "Perplexity"
+    product: "Perplexity API"
+    service: "AI client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "perplexity.Perplexity"
+          - type: call
+            value: "perplexity.AsyncPerplexity"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@perplexity-ai/perplexity_ai"
+          - type: call
+            value: "@perplexity-ai/perplexity_ai/Perplexity"
+          - type: call
+            value: "@perplexity-ai/perplexity_ai/*"

--- a/signatures/pydantic/ai/agents.yaml
+++ b/signatures/pydantic/ai/agents.yaml
@@ -1,0 +1,21 @@
+version: 0.1
+# References -
+# https://pypi.org/project/pydantic-ai/
+
+signatures:
+  - id: pydantic.ai.agent
+    description: "Pydantic AI agent framework"
+    vendor: "Pydantic"
+    product: "Pydantic AI"
+    service: "AI agent runtime"
+    tags: [ai, agent, llm]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "pydantic_ai.Agent"
+          - type: call
+            value: "pydantic_ai.RunContext"
+          - type: call
+            value: "pydantic_ai.*"

--- a/signatures/spring/ai/chat.yaml
+++ b/signatures/spring/ai/chat.yaml
@@ -1,0 +1,22 @@
+version: 0.1
+# References -
+# https://docs.spring.io/spring-ai/reference/
+# https://central.sonatype.com/artifact/org.springframework.ai/spring-ai-client-chat
+
+signatures:
+  - id: spring.ai.chat
+    description: "Spring AI chat client"
+    vendor: "VMware"
+    product: "Spring AI"
+    service: "AI chat client"
+    tags: [ai, llm, text]
+    languages:
+      java:
+        match: any
+        conditions:
+          - type: call
+            value: "org.springframework.ai.chat.client.ChatClient.create"
+          - type: call
+            value: "org.springframework.ai.chat.client.ChatClient.builder"
+          - type: call
+            value: "org.springframework.ai.*"

--- a/signatures/spring/ai/chat.yaml
+++ b/signatures/spring/ai/chat.yaml
@@ -6,7 +6,7 @@ version: 0.1
 signatures:
   - id: spring.ai.chat
     description: "Spring AI chat client"
-    vendor: "VMware"
+    vendor: "Broadcom"
     product: "Spring AI"
     service: "AI chat client"
     tags: [ai, llm, text]

--- a/signatures/togetherai/ai/llm.yaml
+++ b/signatures/togetherai/ai/llm.yaml
@@ -1,0 +1,29 @@
+version: 0.1
+# References -
+# https://pypi.org/project/together/
+# https://www.npmjs.com/package/together-ai
+
+signatures:
+  - id: togetherai.client
+    description: "Together AI API client"
+    vendor: "Together AI"
+    product: "Together API"
+    service: "AI client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "together.Together"
+          - type: call
+            value: "together.AsyncTogether"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "together-ai"
+          - type: call
+            value: "together-ai/Together"
+          - type: call
+            value: "together-ai/*"

--- a/signatures/vercel/ai-sdk/core.yaml
+++ b/signatures/vercel/ai-sdk/core.yaml
@@ -1,0 +1,23 @@
+version: 0.1
+# References -
+# https://www.npmjs.com/package/ai
+
+signatures:
+  - id: vercel.aisdk.core
+    description: "Vercel AI SDK core text generation and agent loop"
+    vendor: "Vercel"
+    product: "AI SDK"
+    service: "AI generation and agents"
+    tags: [ai, llm, agent, text]
+    languages:
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "ai/generateText"
+          - type: call
+            value: "ai/streamText"
+          - type: call
+            value: "ai/ToolLoopAgent"
+          - type: call
+            value: "ai/*"

--- a/signatures/xai/grok/llm.yaml
+++ b/signatures/xai/grok/llm.yaml
@@ -1,0 +1,27 @@
+version: 0.1
+# References -
+# https://pypi.org/project/xai-sdk/
+# https://www.npmjs.com/package/@ai-sdk/xai (Vercel AI SDK provider; xAI has no official npm SDK)
+
+signatures:
+  - id: xai.grok.client
+    description: "xAI Grok API client"
+    vendor: "xAI"
+    product: "Grok"
+    service: "AI client"
+    tags: [ai, llm, text]
+    languages:
+      python:
+        match: any
+        conditions:
+          - type: call
+            value: "xai_sdk.Client"
+          - type: call
+            value: "xai_sdk.AsyncClient"
+          - type: call
+            value: "xai_sdk.*"
+      javascript:
+        match: any
+        conditions:
+          - type: call
+            value: "@ai-sdk/xai/*"


### PR DESCRIPTION
## Summary

Refreshes the AI signatures for xBOM code scanning and extends coverage to the AI SDKs and agent frameworks in common use as of mid-2026. Scope is python, javascript/typescript, and java. Signature count goes from 353 to 387 (34 new signatures across 19 new vendor directories).

**New providers:** xAI Grok, Google Gemini, Mistral, Cohere, Groq, Ollama, AWS Bedrock, Hugging Face, Together AI, Fireworks, Perplexity.
**New frameworks and SDKs:** Vercel AI SDK, LangGraph, LangChain.js, LlamaIndex, OpenAI Agents SDK, Pydantic AI, MCP SDKs (server and client), Claude Agent SDK, Spring AI, Google ADK, Mastra, DashScope/Qwen, AWS Strands, Semantic Kernel, Microsoft Agent Framework, Haystack, Agno, smolagents.
**Refreshed:** OpenAI, Anthropic, and Azure AI files gain working javascript conditions; LangChain gains LangChain.js and v1 python entry points.

DeepSeek and Moonshot/Kimi have no official SDKs (both route through the `openai` SDK), so they are not detectable by call-pattern analysis and are intentionally absent.

## Matcher facts this PR encodes

Discovered and fixture-proven during implementation:

1. JavaScript conditions must use `/` before the imported symbol (`openai/OpenAI`) and `/*` wildcards. Dot forms never match. The pre-existing Azure AI javascript conditions were dead for this reason and are fixed here.
2. A default import (`import OpenAI from "openai"`) resolves to a bare package namespace. Only a bare package-name condition catches its constructor calls; the match is exact, so it cannot over-match named imports.
3. Argument constraints work through the YAML path. First production use: Bedrock python detection via `boto3.client("bedrock-runtime")` with an `args` literal constraint (both quote styles listed, because literals keep their source quote character).

## Verification

- `vet code validate`: all 387 signatures valid, zero duplicate IDs.
- `go test ./pkg/xbom/signatures/`: pass, including one new load-test row per new vendor.
- Every new signature ID matched at least once in fixture scans (source-only apps per ecosystem, scanned with `vet code scan` + `vet code query`), including a java fixture for Spring AI / Google ADK / Gemini.
- Known fixture-unverified conditions (kept on documented upstream reference, marked where speculative): Cohere/Gemini/DashScope/MCP java blocks, Strands javascript, and some named-export variants.

## Follow-ups (pre-existing issues, separate PRs)

- `google/gcp/gcp.yaml` and possibly the javascript stdlib signatures still carry dead dot-form javascript conditions.
- `python.database.dynamodb` matches every `boto3.client` call; the Bedrock `args` pattern is the fix recipe.
- Crypto `args` signatures list only double-quoted literals, so single-quoted python calls are missed.
- `docs/xbom.md` language list and signature-authoring docs updated here; safedep/docs PR #78 needs a matching update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)