### PR TITLE
fix(reporter): surface malicious package lookups that never completed

### DIFF
--- a/pkg/models/manifest_test.go
+++ b/pkg/models/manifest_test.go
@@ -113,3 +113,17 @@ func TestContainerImageManifestAddPackages(t *testing.T) {
 	assert.Equal(t, manifest.Id(), pkg1.Manifest.Id())
 	assert.Equal(t, manifest.Id(), pkg2.Manifest.Id())
 }
+
+func TestMalwareAnalysisLookupErrorCount(t *testing.T) {
+	pm := &PackageManifest{}
+
+	assert.Equal(t, 0, pm.GetMalwareAnalysisLookupErrorCount())
+
+	pm.IncrementMalwareAnalysisLookupError()
+	pm.IncrementMalwareAnalysisLookupError()
+
+	assert.Equal(t, 2, pm.GetMalwareAnalysisLookupErrorCount())
+
+	// Lookup errors and quota errors are tracked independently
+	assert.Equal(t, 0, pm.GetMalwareAnalysisQuotaErrorCount())
+}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -123,6 +123,11 @@ type PackageManifest struct {
 type internalState struct {
 	// Quota error count for malware analysis api
 	malwareAnalysisQuotaErrorCount int
+
+	// Failed lookup count for malware analysis api. This covers any error
+	// other than a quota error, such as a transport failure, a timeout or
+	// the package not being available in the threat intelligence database.
+	malwareAnalysisLookupErrorCount int
 }
 
 // Deprecated: Use NewPackageManifest* initializers
@@ -256,6 +261,18 @@ func (pm *PackageManifest) GetMalwareAnalysisQuotaErrorCount() int {
 	pm.m.RLock()
 	defer pm.m.RUnlock()
 	return pm.internalState.malwareAnalysisQuotaErrorCount
+}
+
+func (pm *PackageManifest) IncrementMalwareAnalysisLookupError() {
+	pm.m.Lock()
+	defer pm.m.Unlock()
+	pm.internalState.malwareAnalysisLookupErrorCount++
+}
+
+func (pm *PackageManifest) GetMalwareAnalysisLookupErrorCount() int {
+	pm.m.RLock()
+	defer pm.m.RUnlock()
+	return pm.internalState.malwareAnalysisLookupErrorCount
 }
 
 func (pm *PackageManifest) GetControlTowerSpecEcosystem() packagev1.Ecosystem {

--- a/pkg/reporter/common.go
+++ b/pkg/reporter/common.go
@@ -60,12 +60,23 @@ func getVulnerabilitySolution(pkg *models.Package) string {
 
 type internalReportConfig struct {
 	malwareAnalysisQuotaLimitErrorCount int
+	malwareAnalysisLookupErrorCount     int
 }
 
 func renderQuotaLimitErrorMessages(quotaExceededErrCnt int) string {
 	return fmt.Sprintf("You have reached your quota for malicious package scanning.\n"+
 		"%d malicious package lookups were denied. Please see safedep.io/pricing for "+
 		"upgrade.", quotaExceededErrCnt)
+}
+
+func renderMalwareLookupErrorMessages(lookupErrCnt int) string {
+	return fmt.Sprintf("%d malicious package lookups did not complete. These packages "+
+		"were not checked for malware. Re-run with `-l -` to see the errors.", lookupErrCnt)
+}
+
+func renderMarkdownMalwareLookupErrorMessages(lookupErrCnt int) string {
+	return fmt.Sprintf("⚠️ `%d` malicious package lookups **did not complete**. These "+
+		"packages were **not** checked for malware.", lookupErrCnt)
 }
 
 func renderMarkdownQuotaLimitErrorMessages(quotaExceededErrCnt int) string {

--- a/pkg/reporter/markdown_summary.go
+++ b/pkg/reporter/markdown_summary.go
@@ -125,6 +125,7 @@ func (r *markdownSummaryReporter) AddManifest(manifest *models.PackageManifest) 
 	}
 
 	r.internalReportConfig.malwareAnalysisQuotaLimitErrorCount += manifest.GetMalwareAnalysisQuotaErrorCount()
+	r.internalReportConfig.malwareAnalysisLookupErrorCount += manifest.GetMalwareAnalysisLookupErrorCount()
 }
 
 func (r *markdownSummaryReporter) AddAnalyzerEvent(event *analyzer.AnalyzerEvent) {
@@ -167,6 +168,12 @@ func (r *markdownSummaryReporter) Finish() error {
 	if quotaLimitErrorCount > 0 {
 		builder.AddHorizontalRule()
 		builder.AddParagraph(renderMarkdownQuotaLimitErrorMessages(quotaLimitErrorCount))
+	}
+
+	lookupErrorCount := r.internalReportConfig.malwareAnalysisLookupErrorCount
+	if lookupErrorCount > 0 {
+		builder.AddHorizontalRule()
+		builder.AddParagraph(renderMarkdownMalwareLookupErrorMessages(lookupErrorCount))
 	}
 
 	err = os.WriteFile(r.config.Path, []byte(builder.Build()), 0o600)

--- a/pkg/reporter/summary.go
+++ b/pkg/reporter/summary.go
@@ -172,6 +172,7 @@ func (r *summaryReporter) AddManifest(manifest *models.PackageManifest) {
 	r.summary.manifests += 1
 
 	r.internalReportConfig.malwareAnalysisQuotaLimitErrorCount += manifest.GetMalwareAnalysisQuotaErrorCount()
+	r.internalReportConfig.malwareAnalysisLookupErrorCount += manifest.GetMalwareAnalysisLookupErrorCount()
 }
 
 func (r *summaryReporter) AddAnalyzerEvent(event *analyzer.AnalyzerEvent) {
@@ -448,6 +449,14 @@ func (r *summaryReporter) Finish() error {
 	quotaErrorCnt := r.internalReportConfig.malwareAnalysisQuotaLimitErrorCount
 	if quotaErrorCnt > 0 {
 		fmt.Println(CriticalBgText((renderQuotaLimitErrorMessages(quotaErrorCnt))))
+		fmt.Println()
+	}
+
+	// Add error for lookups that never completed. Without this the malware
+	// analysis statement above reads as a clean result.
+	lookupErrorCnt := r.internalReportConfig.malwareAnalysisLookupErrorCount
+	if lookupErrorCnt > 0 {
+		fmt.Println(CriticalBgText(renderMalwareLookupErrorMessages(lookupErrorCnt)))
 		fmt.Println()
 	}
 

--- a/pkg/reporter/summary_test.go
+++ b/pkg/reporter/summary_test.go
@@ -70,4 +70,19 @@ func TestRenderInternalErrorMessages(t *testing.T) {
 
 		assert.Equal(t, expectedErrorMessage, actualErrorMessage)
 	})
+
+	t.Run("when malware lookup error count is greater than 0", func(t *testing.T) {
+		t.Parallel()
+
+		r := &summaryReporter{}
+		r.internalReportConfig.malwareAnalysisLookupErrorCount = 3
+
+		expectedErrorMessage := "3 malicious package lookups did not complete. These " +
+			"packages were not checked for malware. Re-run with `-l -` to see the errors."
+
+		actualErrorMessage := renderMalwareLookupErrorMessages(3)
+
+		assert.Equal(t, expectedErrorMessage, actualErrorMessage)
+		assert.Equal(t, 3, r.internalReportConfig.malwareAnalysisLookupErrorCount)
+	})
 }

--- a/pkg/scanner/enrich_malware_query.go
+++ b/pkg/scanner/enrich_malware_query.go
@@ -138,6 +138,12 @@ func (e *malysisMalwareAnalysisQueryEnricher) Enrich(pkg *models.Package, cb Pac
 			return nil
 		}
 
+		// Record the failed lookup so reporters can distinguish "looked up and
+		// found nothing" from "the lookup never completed". Without this the
+		// summary reports 0/N packages scanned for malware, which is
+		// indistinguishable from a clean result.
+		pkg.Manifest.IncrementMalwareAnalysisLookupError()
+
 		return fmt.Errorf("failed to query package analysis: %w", err)
 	}
 

--- a/pkg/scanner/enrich_malware_query_test.go
+++ b/pkg/scanner/enrich_malware_query_test.go
@@ -96,6 +96,7 @@ func TestMalysisMalwareAnalysisQueryEnricherEnrich(t *testing.T) {
 		mockError             error
 		expectedError         bool
 		expectMalwareAnalysis bool
+		expectLookupErrors    int
 	}{
 		{
 			name: "successful enrichment for npm package",
@@ -126,6 +127,7 @@ func TestMalysisMalwareAnalysisQueryEnricherEnrich(t *testing.T) {
 			mockError:             assert.AnError,
 			expectedError:         true,
 			expectMalwareAnalysis: false,
+			expectLookupErrors:    1,
 		},
 		{
 			name: "excluded query result is ignored at source",
@@ -180,6 +182,11 @@ func TestMalysisMalwareAnalysisQueryEnricherEnrich(t *testing.T) {
 			err := enricher.Enrich(tc.pkg, func(_ *models.Package) error {
 				return nil
 			})
+
+			// A failed lookup must be recorded on the manifest so reporters can
+			// tell it apart from a package that was looked up and came back clean
+			assert.Equal(t, tc.expectLookupErrors,
+				tc.pkg.Manifest.GetMalwareAnalysisLookupErrorCount())
 
 			if tc.expectedError {
 				assert.Error(t, err)


### PR DESCRIPTION
Partially addresses #739. **Not a close** — see the caveat at the bottom.

## Problem

When a malicious package lookup fails, the error only reaches the log file. `packageEnrichWorkQueueHandler` logs and swallows it:

```go
err := enricher.Enrich(item, s.packageDependencyHandler(pm, item, q))
if err != nil {
    logger.Errorf("Enricher %s failed with %v", enricher.Name(), err)
}
```

(`pkg/scanner/scanner.go`)

The summary then prints:

```
** 0/1 libraries were scanned for malware
```

which is indistinguishable from "we looked up every package and they all came back clean". Because logs are redirected to a file by default, the user gets no signal that the check never completed. In #739 this reads as vet being unable to identify a package that `vet inspect malware` flags as suspicious.

## Change

Track failed lookups on the package manifest and surface the count at the end of the summary and markdown summary reports. This mirrors the existing mechanism for quota errors (`IncrementMalwareAnalysisQuotaError` → `malwareAnalysisQuotaLimitErrorCount` → rendered after the findings), so the two error classes stay distinct: quota-denied lookups keep their existing pricing message, everything else (transport failure, timeout, package absent from the threat intelligence database) counts as a failed lookup.

New output when lookups fail:

```
3 malicious package lookups did not complete. These packages were not
checked for malware. Re-run with `-l -` to see the errors.
```

This does **not** change which packages get flagged. It makes an incomplete malware check visible instead of silent.

## Tests

- `pkg/scanner`: extends the enricher table test to assert the failure is recorded on the manifest. Verified it fails without the fix (`expected: 1, actual: 0`).
- `pkg/reporter`: message rendering test alongside the existing quota one.
- `pkg/models`: counter increments, and stays independent of the quota counter.

`go test ./pkg/models/... ./pkg/reporter/... ./pkg/scanner/...` passes; `go vet ./...` and `gofmt` are clean.

## Caveat on #739

This does not make `vet scan` report `epochly@0.6.3` as suspicious. I ruled out two candidate root causes for that:

- `--malware-query` defaults to `true`, so the query enricher does run on a plain `vet scan`.
- `pkg:/pypi/epochly@0.6.3` resolves correctly to `ECOSYSTEM_PYPI` / `epochly` / `0.6.3` through `purlReader`, so the request is well-formed.

The remaining difference is that `vet scan` only queries existing analysis records, while `vet inspect malware` at v1.17.2 submitted the package and waited for a fresh verdict. Whether a `SUSPICIOUS` / `MEDIUM`-confidence automated result should be queryable is a server-side question I can't verify from the client. Happy to follow up if maintainers can confirm the intended behaviour — I left the details in a comment on #739.
