### PR TITLE
fix(malysis): support VS Code and OpenVSX ecosystems in OSV reports

### DIFF
--- a/pkg/malysis/ossf.go
+++ b/pkg/malysis/ossf.go
@@ -92,7 +92,10 @@ func (g *openSSFMaliciousPackageReportGenerator) GenerateReport(ctx context.Cont
 
 	// Determine the appropriate range type based on ecosystem
 	rangeType := osvschema.Range_SEMVER
-	if report.GetPackageVersion().GetPackage().GetEcosystem() == packagev1.Ecosystem_ECOSYSTEM_PYPI {
+	switch report.GetPackageVersion().GetPackage().GetEcosystem() {
+	case packagev1.Ecosystem_ECOSYSTEM_PYPI,
+		packagev1.Ecosystem_ECOSYSTEM_VSCODE,
+		packagev1.Ecosystem_ECOSYSTEM_OPENVSX:
 		rangeType = osvschema.Range_ECOSYSTEM
 	}
 
@@ -190,6 +193,8 @@ var filePathEcosystemMap = map[packagev1.Ecosystem]string{
 	packagev1.Ecosystem_ECOSYSTEM_GO:       "go",
 	packagev1.Ecosystem_ECOSYSTEM_MAVEN:    "maven",
 	packagev1.Ecosystem_ECOSYSTEM_CARGO:    "crates-io",
+	packagev1.Ecosystem_ECOSYSTEM_VSCODE:   "vscode",
+	packagev1.Ecosystem_ECOSYSTEM_OPENVSX:  "vscode:open-vsx.org",
 }
 
 // OSV schema ecosystem mapping with proper case-sensitive ecosystem names for OSV JSON schema compliance.
@@ -201,6 +206,8 @@ var osvEcosystemMap = map[packagev1.Ecosystem]string{
 	packagev1.Ecosystem_ECOSYSTEM_GO:       "Go",
 	packagev1.Ecosystem_ECOSYSTEM_MAVEN:    "Maven",
 	packagev1.Ecosystem_ECOSYSTEM_CARGO:    "crates.io",
+	packagev1.Ecosystem_ECOSYSTEM_VSCODE:   "VSCode",
+	packagev1.Ecosystem_ECOSYSTEM_OPENVSX:  "VSCode:https://open-vsx.org",
 }
 
 func (g *openSSFMaliciousPackageReportGenerator) osvEcosystemFor(ecosystem packagev1.Ecosystem) (string, error) {
@@ -240,6 +247,10 @@ func (g *openSSFMaliciousPackageReportGenerator) relativeFilePath(ecosystem pack
 		return fmt.Sprintf("%s/maven/%s/MAL-0000-%s.json", prefix, packageName, packageFileName), nil
 	case "crates-io":
 		return fmt.Sprintf("%s/crates-io/%s/MAL-0000-%s.json", prefix, packageName, packageFileName), nil
+	case "vscode":
+		return fmt.Sprintf("%s/vscode/%s/MAL-0000-%s.json", prefix, packageName, packageFileName), nil
+	case "vscode:open-vsx.org":
+		return fmt.Sprintf("%s/vscode:open-vsx.org/%s/MAL-0000-%s.json", prefix, packageName, packageFileName), nil
 	default:
 		return "", fmt.Errorf("unsupported ecosystem: %s", ecosystemStr)
 	}

--- a/pkg/malysis/ossf_test.go
+++ b/pkg/malysis/ossf_test.go
@@ -28,6 +28,8 @@ func TestOpenSSFMaliciousPackageReportGenerator_relativeFilePath(t *testing.T) {
 		{name: "go", ecosystem: packagev1.Ecosystem_ECOSYSTEM_GO, packageName: "github.com/test/test", want: "osv/malicious/go/github.com/test/test/MAL-0000-github.com-test-test.json", wantErr: nil},
 		{name: "maven", ecosystem: packagev1.Ecosystem_ECOSYSTEM_MAVEN, packageName: "org.example.test:test", want: "osv/malicious/maven/org.example.test:test/MAL-0000-org.example.test-test.json", wantErr: nil},
 		{name: "crates-io", ecosystem: packagev1.Ecosystem_ECOSYSTEM_CARGO, packageName: "test", want: "osv/malicious/crates-io/test/MAL-0000-test.json", wantErr: nil},
+		{name: "vscode", ecosystem: packagev1.Ecosystem_ECOSYSTEM_VSCODE, packageName: "publisher.extension", want: "osv/malicious/vscode/publisher.extension/MAL-0000-publisher.extension.json", wantErr: nil},
+		{name: "openvsx", ecosystem: packagev1.Ecosystem_ECOSYSTEM_OPENVSX, packageName: "publisher.extension", want: "osv/malicious/vscode:open-vsx.org/publisher.extension/MAL-0000-publisher.extension.json", wantErr: nil},
 		{name: "unknown", ecosystem: packagev1.Ecosystem_ECOSYSTEM_UNSPECIFIED, packageName: "test", want: "", wantErr: fmt.Errorf("unsupported ecosystem: %s", packagev1.Ecosystem_ECOSYSTEM_UNSPECIFIED)},
 	}
 
@@ -353,6 +355,80 @@ func TestOpenSSFMaliciousPackageReportGenerator_GenerateReport(t *testing.T) {
 				assert.Len(t, vuln.Affected, 1, "should have one affected package")
 				assert.Len(t, vuln.Affected[0].Versions, 1, "should have one explicit version")
 				assert.Equal(t, "1.0.0", vuln.Affected[0].Versions[0], "version should match package version")
+			},
+		},
+		{
+			name: "VS Code marketplace extension uses vscode path and VSCode ecosystem",
+			report: &malysisv1pb.Report{
+				PackageVersion: &packagev1.PackageVersion{
+					Package: &packagev1.Package{
+						Ecosystem: packagev1.Ecosystem_ECOSYSTEM_VSCODE,
+						Name:      "publisher.malicious-ext",
+					},
+					Version: "1.2.3",
+				},
+				Inference: &malysisv1pb.Report_Inference{
+					Summary: "Malicious VS Code extension",
+					Details: "Test details",
+				},
+			},
+			params: OpenSSFMaliciousPackageReportParams{
+				UseRange: true,
+			},
+			setup: func(t *testing.T, dir string) {
+				_ = os.MkdirAll(dir, 0o755)
+			},
+			assert: func(t *testing.T, dir string, err error) {
+				assert.NoError(t, err)
+				filePath := filepath.Join(dir, "osv/malicious/vscode/publisher.malicious-ext/MAL-0000-publisher.malicious-ext.json")
+				assert.FileExists(t, filePath)
+
+				jsonFile, err := os.ReadFile(filePath)
+				assert.NoError(t, err)
+
+				var vuln osvschema.Vulnerability
+				err = protojson.Unmarshal(jsonFile, &vuln)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "VSCode", vuln.Affected[0].Package.Ecosystem)
+				assert.Equal(t, "publisher.malicious-ext", vuln.Affected[0].Package.Name)
+				assert.Equal(t, osvschema.Range_ECOSYSTEM, vuln.Affected[0].Ranges[0].Type)
+			},
+		},
+		{
+			name: "OpenVSX extension uses vscode:open-vsx.org path and ecosystem",
+			report: &malysisv1pb.Report{
+				PackageVersion: &packagev1.PackageVersion{
+					Package: &packagev1.Package{
+						Ecosystem: packagev1.Ecosystem_ECOSYSTEM_OPENVSX,
+						Name:      "publisher.openvsx-ext",
+					},
+					Version: "4.5.6",
+				},
+				Inference: &malysisv1pb.Report_Inference{
+					Summary: "Malicious OpenVSX extension",
+					Details: "Test details",
+				},
+			},
+			setup: func(t *testing.T, dir string) {
+				_ = os.MkdirAll(dir, 0o755)
+			},
+			assert: func(t *testing.T, dir string, err error) {
+				assert.NoError(t, err)
+				filePath := filepath.Join(dir, "osv/malicious/vscode:open-vsx.org/publisher.openvsx-ext/MAL-0000-publisher.openvsx-ext.json")
+				assert.FileExists(t, filePath)
+
+				jsonFile, err := os.ReadFile(filePath)
+				assert.NoError(t, err)
+
+				var vuln osvschema.Vulnerability
+				err = protojson.Unmarshal(jsonFile, &vuln)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "VSCode:https://open-vsx.org", vuln.Affected[0].Package.Ecosystem)
+				assert.Equal(t, "publisher.openvsx-ext", vuln.Affected[0].Package.Name)
+				assert.Len(t, vuln.Affected[0].Versions, 1)
+				assert.Equal(t, "4.5.6", vuln.Affected[0].Versions[0])
 			},
 		},
 	}

--- a/pkg/malysis/ossf_test.go
+++ b/pkg/malysis/ossf_test.go
@@ -410,6 +410,9 @@ func TestOpenSSFMaliciousPackageReportGenerator_GenerateReport(t *testing.T) {
 					Details: "Test details",
 				},
 			},
+			params: OpenSSFMaliciousPackageReportParams{
+				UseRange: true,
+			},
 			setup: func(t *testing.T, dir string) {
 				_ = os.MkdirAll(dir, 0o755)
 			},
@@ -427,8 +430,7 @@ func TestOpenSSFMaliciousPackageReportGenerator_GenerateReport(t *testing.T) {
 
 				assert.Equal(t, "VSCode:https://open-vsx.org", vuln.Affected[0].Package.Ecosystem)
 				assert.Equal(t, "publisher.openvsx-ext", vuln.Affected[0].Package.Name)
-				assert.Len(t, vuln.Affected[0].Versions, 1)
-				assert.Equal(t, "4.5.6", vuln.Affected[0].Versions[0])
+				assert.Equal(t, osvschema.Range_ECOSYSTEM, vuln.Affected[0].Ranges[0].Type)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Add VS Code Marketplace and OpenVSX extension support to the OpenSSF malicious package OSV report generator used by `vet inspect malware --report-osv`.

This continues the work from #751 by @syf2211, who has stopped responding. It carries their two commits, rebased onto the latest `main` (the source PR was behind), so CI runs and the change can merge.

Fixes #651. Supersedes #751.

## Motivation

`--report-osv` failed with `unsupported ecosystem` for VS Code / OpenVSX extension malware analysis. OSSF `malicious-packages` already keeps advisories under `osv/malicious/vscode` and `osv/malicious/vscode:open-vsx.org`, but the generator only mapped npm, PyPI, RubyGems, Go, Maven, and crates.io.

## Changes

- Map `ECOSYSTEM_VSCODE` to file path `vscode` and OSV ecosystem `VSCode`
- Map `ECOSYSTEM_OPENVSX` to file path `vscode:open-vsx.org` and OSV ecosystem `VSCode:https://open-vsx.org`
- Use the `ECOSYSTEM` range type for VS Code marketplaces (same as PyPI)
- Add unit tests for path generation and report output for both ecosystems

## Review notes from #751

- The OpenVSX report test now uses `UseRange: true` and asserts `Range_ECOSYSTEM`, matching the VS Code test (the last open Copilot points).
- The `:` in the `vscode:open-vsx.org` directory name is intentional. It matches the OSSF `malicious-packages` layout, as confirmed by the maintainer on #751.

## Verification

- `go build ./...` - pass
- `go test ./pkg/malysis/... -count=1` - pass
- `golangci-lint run ./pkg/malysis/...` - 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013n6Sf2jPkgdcbBP3MMBHYi)_