### PR TITLE
fix(test): make GitHub reader e2e test resilient to live repo changes

### DIFF
--- a/test/e2e_github_reader_test.go
+++ b/test/e2e_github_reader_test.go
@@ -45,23 +45,37 @@ func TestGithubReaderWithVetPublicRepository(t *testing.T) {
 
 		assert.Nil(t, err)
 
-		assert.Equal(t, len(manifests), 2)
+		// The scanned repositories are live and their contents change over
+		// time. Assert that the expected manifests are present instead of
+		// asserting exact counts and positions.
+		assert.GreaterOrEqual(t, len(manifests), 2)
 
-		assert.NotNil(t, manifests[0])
-		assert.NotNil(t, manifests[1])
+		findManifest := func(displayPath, blobURLPrefix string) *models.PackageManifest {
+			for _, pm := range manifests {
+				if pm.GetDisplayPath() == displayPath &&
+					strings.HasPrefix(pm.GetPath(), blobURLPrefix) {
+					return pm
+				}
+			}
+			return nil
+		}
 
-		assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_GO, manifests[0].GetControlTowerSpecEcosystem())
-		assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_MAVEN, manifests[1].GetControlTowerSpecEcosystem())
+		goManifest := findManifest("go.mod",
+			"https://api.github.com/repos/safedep/vet/git/blobs/")
+		assert.NotNil(t, goManifest, "go.mod not found in safedep/vet")
 
-		assert.Equal(t, "go.mod", manifests[0].GetDisplayPath(), "found in GitHub repository")
-		assert.True(t, strings.HasPrefix(manifests[0].GetPath(),
-			"https://api.github.com/repos/safedep/vet/git/blobs/"))
+		gradleManifest := findManifest("gradle.lockfile",
+			"https://api.github.com/repos/safedep/demo-client-java/git/blobs/")
+		assert.NotNil(t, gradleManifest, "gradle.lockfile not found in safedep/demo-client-java")
 
-		assert.Equal(t, "gradle.lockfile", manifests[1].GetDisplayPath(), "found in GitHub repository")
-		assert.True(t, strings.HasPrefix(manifests[1].GetPath(),
-			"https://api.github.com/repos/safedep/demo-client-java/git/blobs/"))
+		if goManifest != nil {
+			assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_GO, goManifest.GetControlTowerSpecEcosystem())
+			assert.Greater(t, len(goManifest.Packages), 0)
+		}
 
-		assert.Greater(t, len(manifests[0].Packages), 0)
-		assert.Greater(t, len(manifests[1].Packages), 0)
+		if gradleManifest != nil {
+			assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_MAVEN, gradleManifest.GetControlTowerSpecEcosystem())
+			assert.Greater(t, len(gradleManifest.Packages), 0)
+		}
 	})
 }

--- a/test/e2e_github_reader_test.go
+++ b/test/e2e_github_reader_test.go
@@ -7,6 +7,7 @@ import (
 
 	packagev1 "buf.build/gen/go/safedep/api/protocolbuffers/go/safedep/messages/package/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/safedep/vet/internal/connect"
 	"github.com/safedep/vet/pkg/models"
@@ -62,20 +63,16 @@ func TestGithubReaderWithVetPublicRepository(t *testing.T) {
 
 		goManifest := findManifest("go.mod",
 			"https://api.github.com/repos/safedep/vet/git/blobs/")
-		assert.NotNil(t, goManifest, "go.mod not found in safedep/vet")
+		require.NotNil(t, goManifest, "go.mod not found in safedep/vet")
 
 		gradleManifest := findManifest("gradle.lockfile",
 			"https://api.github.com/repos/safedep/demo-client-java/git/blobs/")
-		assert.NotNil(t, gradleManifest, "gradle.lockfile not found in safedep/demo-client-java")
+		require.NotNil(t, gradleManifest, "gradle.lockfile not found in safedep/demo-client-java")
 
-		if goManifest != nil {
-			assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_GO, goManifest.GetControlTowerSpecEcosystem())
-			assert.Greater(t, len(goManifest.Packages), 0)
-		}
+		assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_GO, goManifest.GetControlTowerSpecEcosystem())
+		assert.Greater(t, len(goManifest.Packages), 0)
 
-		if gradleManifest != nil {
-			assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_MAVEN, gradleManifest.GetControlTowerSpecEcosystem())
-			assert.Greater(t, len(gradleManifest.Packages), 0)
-		}
+		assert.Equal(t, packagev1.Ecosystem_ECOSYSTEM_MAVEN, gradleManifest.GetControlTowerSpecEcosystem())
+		assert.Greater(t, len(gradleManifest.Packages), 0)
 	})
 }


### PR DESCRIPTION
## Problem

`TestGithubReaderWithVetPublicRepository` fails on every CI run since #741 merged, including PRs that only touch the README (see [this run](https://github.com/safedep/vet/actions/runs/31684584821/job/94423348584)).

The test scans the live `safedep/vet` and `safedep/demo-client-java` repositories over the GitHub API. It asserted an exact manifest count (2) and exact positions (`manifests[0]` = `go.mod`, `manifests[1]` = `gradle.lockfile`). #741 added `package.json` and `pnpm-lock.yaml` at the repository root, so the reader now finds 4 manifests and every assertion after the count fails.

## Fix

Assert that the expected manifests are present instead of asserting exact counts and positions:

- The result contains `go.mod` from `safedep/vet` with the Go ecosystem and at least one package.
- The result contains `gradle.lockfile` from `safedep/demo-client-java` with the Maven ecosystem and at least one package.
- The total manifest count is at least 2.

The test no longer breaks when a root-level manifest is added to or removed from the live repository.

## Test

```
VET_E2E=true go test ./test/ -run TestGithubReaderWithVetPublicRepository -v
--- PASS: TestGithubReaderWithVetPublicRepository (3.49s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)