### PR TITLE
docs: restore star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ export VET_DISABLE_TELEMETRY=true
 
 <div align="center">
 
+### ⭐ Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=safedep/vet&type=Date)](https://star-history.dera.page/#safedep/vet&Date)
+
 ### Built With Open Source
 
 vet stands on the shoulders of giants:


### PR DESCRIPTION
The star history chart in the README was removed in d96339c (docs: Update README (#763)), but it is currently broken because of GitHub stargazer API restrictions. This change restores it at the same location using a working data source so the chart renders correctly again.