### PR TITLE
fix(models): emit spec-compliant PURLs for distro ecosystems

### DIFF
--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -491,7 +491,58 @@ func (p *Package) GetProvenances() []*Provenance {
 	return p.Provenances
 }
 
+// distroEcosystemPurls maps OSV distro ecosystem families (lowercase,
+// spaces/dashes stripped) to their PURL type and namespace, per the PURL
+// spec for OS packages (https://github.com/package-url/purl-spec).
+var distroEcosystemPurls = map[string]struct {
+	pkgType   string
+	namespace string
+}{
+	"alpine":                {"apk", "alpine"},
+	"debian":                {"deb", "debian"},
+	"ubuntu":                {"deb", "ubuntu"},
+	"centos":                {"rpm", "centos"},
+	"fedora":                {"rpm", "fedora"},
+	"rockylinux":            {"rpm", "rockylinux"},
+	"almalinux":             {"rpm", "almalinux"},
+	"amazonlinux":           {"rpm", "amazonlinux"},
+	"oraclelinux":           {"rpm", "oraclelinux"},
+	"redhatenterpriselinux": {"rpm", "rhel"},
+}
+
+// distroPurlForEcosystem converts an OSV-style distro ecosystem string
+// (e.g. "Alpine:v3.20") into its PURL type, namespace and distro version.
+// Returns false when the ecosystem is not a known distro family or has
+// no distro suffix.
+func distroPurlForEcosystem(ecosystem string) (string, string, string, bool) {
+	family, distro, found := strings.Cut(ecosystem, ":")
+	if !found || strings.TrimSpace(distro) == "" {
+		return "", "", "", false
+	}
+
+	norm := strings.ToLower(family)
+	norm = strings.ReplaceAll(norm, " ", "")
+	norm = strings.ReplaceAll(norm, "-", "")
+
+	info, ok := distroEcosystemPurls[norm]
+	if !ok {
+		return "", "", "", false
+	}
+
+	return info.pkgType, info.namespace, distro, true
+}
+
+// GetPackageUrl returns the PURL of the package. Distro ecosystems found
+// during container scanning (e.g. "Alpine:v3.20") cannot be used directly
+// as a PURL type; they are rendered with their package manager type and a
+// distro qualifier instead: pkg:apk/alpine/musl@1.2.5-r21?distro=v3.20
 func (p *Package) GetPackageUrl() string {
+	if pkgType, namespace, distro, ok := distroPurlForEcosystem(string(p.Ecosystem)); ok {
+		return fmt.Sprintf("pkg:%s/%s/%s@%s?distro=%s",
+			pkgType, namespace,
+			strings.ToLower(p.Name), p.Version, distro)
+	}
+
 	return fmt.Sprintf("pkg:%s/%s@%s",
 		strings.ToLower(string(p.Ecosystem)),
 		strings.ToLower(p.Name), p.Version)

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -516,7 +516,8 @@ var distroEcosystemPurls = map[string]struct {
 // no distro suffix.
 func distroPurlForEcosystem(ecosystem string) (string, string, string, bool) {
 	family, distro, found := strings.Cut(ecosystem, ":")
-	if !found || strings.TrimSpace(distro) == "" {
+	distro = strings.TrimSpace(distro)
+	if !found || distro == "" {
 		return "", "", "", false
 	}
 
@@ -534,8 +535,10 @@ func distroPurlForEcosystem(ecosystem string) (string, string, string, bool) {
 
 // GetPackageUrl returns the PURL of the package. Distro ecosystems found
 // during container scanning (e.g. "Alpine:v3.20") cannot be used directly
-// as a PURL type; they are rendered with their package manager type and a
-// distro qualifier instead: pkg:apk/alpine/musl@1.2.5-r21?distro=v3.20
+// as a PURL type; known distro families are rendered with their package
+// manager type and a distro qualifier instead:
+// pkg:apk/alpine/musl@1.2.5-r21?distro=v3.20 Unknown ecosystems, including
+// unrecognized distro families, keep the legacy rendering.
 func (p *Package) GetPackageUrl() string {
 	if pkgType, namespace, distro, ok := distroPurlForEcosystem(string(p.Ecosystem)); ok {
 		return fmt.Sprintf("pkg:%s/%s/%s@%s?distro=%s",

--- a/pkg/models/purl_test.go
+++ b/pkg/models/purl_test.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPackageUrl(t *testing.T) {
+	cases := []struct {
+		name      string
+		ecosystem string
+		pkgName   string
+		version   string
+		expected  string
+	}{
+		{
+			name:      "alpine distro ecosystem uses apk type with distro qualifier",
+			ecosystem: "Alpine:v3.20",
+			pkgName:   "musl",
+			version:   "1.2.5-r21",
+			expected:  "pkg:apk/alpine/musl@1.2.5-r21?distro=v3.20",
+		},
+		{
+			name:      "ubuntu distro ecosystem maps to deb with ubuntu namespace",
+			ecosystem: "Ubuntu:22.04",
+			pkgName:   "adduser",
+			version:   "3.118ubuntu5",
+			expected:  "pkg:deb/ubuntu/adduser@3.118ubuntu5?distro=22.04",
+		},
+		{
+			name:      "red hat family normalizes to rhel rpm purl",
+			ecosystem: "Red Hat Enterprise Linux:8",
+			pkgName:   "curl",
+			version:   "7.61.1-30.el8",
+			expected:  "pkg:rpm/rhel/curl@7.61.1-30.el8?distro=8",
+		},
+		{
+			name:      "unknown distro family keeps legacy rendering",
+			ecosystem: "UnknownOS:1.0",
+			pkgName:   "pkg-a",
+			version:   "1.0",
+			expected:  "pkg:unknownos:1.0/pkg-a@1.0",
+		},
+		{
+			name:      "non distro ecosystems keep legacy rendering",
+			ecosystem: "npm",
+			pkgName:   "left-pad",
+			version:   "1.3.0",
+			expected:  "pkg:npm/left-pad@1.3.0",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := &Package{PackageDetails: lockfile.PackageDetails{
+				Ecosystem: lockfile.Ecosystem(c.ecosystem),
+				Name:      c.pkgName,
+				Version:   c.version,
+			}}
+
+			assert.Equal(t, c.expected, p.GetPackageUrl())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #500

## Problem

Container scanning derives package ecosystems from osv-scalibr in OSV form, e.g. Alpine:v3.20, Debian:12. Package.GetPackageUrl() rendered these with the raw ecosystem string as the PURL type:

``
pkg:alpine:v3.20/musl@1.2.5-r21 n``

This is an invalid PURL: the type segment cannot contain a colon, and there is no such purl type as `alpine:v3.20`. These broken PURLs propagate into CycloneDX SBOMs and the SQLite reporter for every OS package found in a container image.

## Fix

Render distro ecosystems per the PURL spec for OS packages - package manager type + namespace + `distro` qualifier:

- `Alpine:v3.20` -> `pkg:apk/alpine/musl@1.2.5-r21?distro=v3.20` (matches the `pkg:apk/alpine/alpine-baselayout@3.7.1-r8?arch=x86_64&distro=3.23.3` shape from the issue)
- `Ubuntu:22.04` -> `pkg:deb/ubuntu/adduser@3.118ubuntu5?distro=22.04` (matches the `pkg:deb/ubuntu/adduser@...&distro=jammy` shape from the issue)
- `Red Hat Enterprise Linux:8` -> `pkg:rpm/rhel/curl@...?distro=8` (family names are normalized so spaces/dashes don't matter)
- Unknown families and non-distro ecosystems keep the existing rendering, so nothing else changes.

Added table tests in `pkg/models/purl_test.go` covering alpine/ubuntu/RHEL/unknown/npm cases.

## Notes on #500

The full ask in #500 (backend enrichment for OS-specific advisories) is server-side; this PR fixes the client-side PURL contract discussed in the issue so downstream consumers (CycloneDX, SQLite) receive valid, distro-scoped PURLs.