### PR TITLE
feat(auth): retry transient failures and time out cloud gRPC calls

### DIFF
--- a/internal/auth/grpc.go
+++ b/internal/auth/grpc.go
@@ -1,15 +1,32 @@
 package auth
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
+	"time"
 
 	drygrpc "github.com/safedep/dry/adapters/grpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 
 	"github.com/safedep/vet/pkg/common/logger"
+)
+
+const (
+	cloudGrpcMaxAttemptsEnvKey = "VET_CLOUD_GRPC_MAX_ATTEMPTS"
+	cloudGrpcTimeoutEnvKey     = "VET_CLOUD_GRPC_TIMEOUT"
+
+	// gRPC caps client side retry attempts at 5, so the configured value is
+	// clamped to [1, 5]. A value of 1 disables retries.
+	defaultCloudGrpcMaxAttempts = 4
+	maxCloudGrpcMaxAttempts     = 5
+
+	// Per call deadline applied to cloud RPCs that do not set their own.
+	defaultCloudGrpcTimeout = 30 * time.Second
 )
 
 // Create a gRPC client connection for the control plane
@@ -61,10 +78,116 @@ func cloudClientConnection(name, loc, tok string) (*grpc.ClientConn, error) {
 	}
 
 	client, err := drygrpc.GrpcClient(name, host, port,
-		tok, headers, []grpc.DialOption{})
+		tok, headers, cloudDialOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
 	}
 
 	return client, nil
+}
+
+// cloudDialOptions returns the resiliency dial options applied to every gRPC
+// connection to SafeDep Cloud. It bounds reconnect backoff so a client recovers
+// quickly once the backend is healthy again, applies a default per call
+// deadline, and retries transient UNAVAILABLE failures that are common while the
+// control plane is scaling.
+func cloudDialOptions() []grpc.DialOption {
+	opts := []grpc.DialOption{
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: backoff.Config{
+				BaseDelay:  1 * time.Second,
+				Multiplier: 1.6,
+				Jitter:     0.2,
+				MaxDelay:   15 * time.Second,
+			},
+			MinConnectTimeout: 20 * time.Second,
+		}),
+	}
+
+	if sc, ok := cloudServiceConfig(); ok {
+		opts = append(opts, grpc.WithDefaultServiceConfig(sc))
+	}
+
+	return opts
+}
+
+// cloudServiceConfig builds the default gRPC service config JSON for cloud
+// connections. It returns false when neither a timeout nor retries are
+// configured, so gRPC keeps its own defaults.
+func cloudServiceConfig() (string, bool) {
+	attempts := cloudGrpcMaxAttempts()
+	timeout := cloudGrpcTimeout()
+
+	if timeout <= 0 && attempts <= 1 {
+		return "", false
+	}
+
+	// An empty name entry matches every method on every service.
+	method := map[string]any{
+		"name": []map[string]any{{}},
+	}
+
+	if timeout > 0 {
+		method["timeout"] = fmt.Sprintf("%gs", timeout.Seconds())
+	}
+
+	// A retry policy needs at least two attempts to be valid.
+	if attempts > 1 {
+		method["retryPolicy"] = map[string]any{
+			"maxAttempts":          attempts,
+			"initialBackoff":       "0.5s",
+			"maxBackoff":           "10s",
+			"backoffMultiplier":    2.0,
+			"retryableStatusCodes": []string{"UNAVAILABLE"},
+		}
+	}
+
+	cfg := map[string]any{
+		"methodConfig": []map[string]any{method},
+	}
+
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		logger.Warnf("failed to build gRPC service config: %v", err)
+		return "", false
+	}
+
+	return string(b), true
+}
+
+func cloudGrpcMaxAttempts() int {
+	v := os.Getenv(cloudGrpcMaxAttemptsEnvKey)
+	if v == "" {
+		return defaultCloudGrpcMaxAttempts
+	}
+
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		logger.Warnf("invalid %s=%q, using default %d",
+			cloudGrpcMaxAttemptsEnvKey, v, defaultCloudGrpcMaxAttempts)
+		return defaultCloudGrpcMaxAttempts
+	}
+
+	if n > maxCloudGrpcMaxAttempts {
+		n = maxCloudGrpcMaxAttempts
+	}
+
+	return n
+}
+
+func cloudGrpcTimeout() time.Duration {
+	v := os.Getenv(cloudGrpcTimeoutEnvKey)
+	if v == "" {
+		return defaultCloudGrpcTimeout
+	}
+
+	// A zero duration (e.g. "0s") disables the default deadline.
+	d, err := time.ParseDuration(v)
+	if err != nil || d < 0 {
+		logger.Warnf("invalid %s=%q, using default %s",
+			cloudGrpcTimeoutEnvKey, v, defaultCloudGrpcTimeout)
+		return defaultCloudGrpcTimeout
+	}
+
+	return d
 }

--- a/internal/auth/grpc_test.go
+++ b/internal/auth/grpc_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// assertValidServiceConfig confirms gRPC accepts the config. NewClient is lazy
+// (it does not dial), but it parses the default service config eagerly and
+// returns an error if the JSON is malformed.
+func assertValidServiceConfig(t *testing.T, sc string) {
+	t.Helper()
+	conn, err := grpc.NewClient("passthrough:///test",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(sc))
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+func TestCloudServiceConfigDefaults(t *testing.T) {
+	t.Setenv(cloudGrpcMaxAttemptsEnvKey, "")
+	t.Setenv(cloudGrpcTimeoutEnvKey, "")
+
+	sc, ok := cloudServiceConfig()
+	require.True(t, ok)
+
+	// gRPC must accept the generated service config.
+	assertValidServiceConfig(t, sc)
+
+	var cfg struct {
+		MethodConfig []struct {
+			Timeout     string `json:"timeout"`
+			RetryPolicy *struct {
+				MaxAttempts          int      `json:"maxAttempts"`
+				RetryableStatusCodes []string `json:"retryableStatusCodes"`
+			} `json:"retryPolicy"`
+		} `json:"methodConfig"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(sc), &cfg))
+	require.Len(t, cfg.MethodConfig, 1)
+
+	mc := cfg.MethodConfig[0]
+	assert.Equal(t, "30s", mc.Timeout)
+	require.NotNil(t, mc.RetryPolicy)
+	assert.Equal(t, defaultCloudGrpcMaxAttempts, mc.RetryPolicy.MaxAttempts)
+	assert.Equal(t, []string{"UNAVAILABLE"}, mc.RetryPolicy.RetryableStatusCodes)
+}
+
+func TestCloudServiceConfigTimeoutOverride(t *testing.T) {
+	t.Setenv(cloudGrpcTimeoutEnvKey, "1m30s")
+
+	sc, ok := cloudServiceConfig()
+	require.True(t, ok)
+	assertValidServiceConfig(t, sc)
+	assert.Contains(t, sc, `"timeout":"90s"`)
+}
+
+func TestCloudServiceConfigRetriesDisabled(t *testing.T) {
+	t.Setenv(cloudGrpcMaxAttemptsEnvKey, "1")
+
+	sc, ok := cloudServiceConfig()
+	require.True(t, ok)
+	assertValidServiceConfig(t, sc)
+	assert.NotContains(t, sc, "retryPolicy")
+	// Timeout is still applied.
+	assert.Contains(t, sc, `"timeout":`)
+}
+
+func TestCloudServiceConfigFullyDisabled(t *testing.T) {
+	t.Setenv(cloudGrpcMaxAttemptsEnvKey, "1")
+	t.Setenv(cloudGrpcTimeoutEnvKey, "0s")
+
+	_, ok := cloudServiceConfig()
+	assert.False(t, ok)
+}
+
+func TestCloudGrpcMaxAttempts(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset", "", defaultCloudGrpcMaxAttempts},
+		{"valid", "3", 3},
+		{"clamped", "9", maxCloudGrpcMaxAttempts},
+		{"invalid", "abc", defaultCloudGrpcMaxAttempts},
+		{"below range", "0", defaultCloudGrpcMaxAttempts},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(cloudGrpcMaxAttemptsEnvKey, tc.env)
+			assert.Equal(t, tc.want, cloudGrpcMaxAttempts())
+		})
+	}
+}
+
+func TestCloudGrpcTimeout(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv(cloudGrpcTimeoutEnvKey, "")
+		assert.Equal(t, defaultCloudGrpcTimeout, cloudGrpcTimeout())
+	})
+
+	t.Run("invalid falls back", func(t *testing.T) {
+		t.Setenv(cloudGrpcTimeoutEnvKey, "nope")
+		assert.Equal(t, defaultCloudGrpcTimeout, cloudGrpcTimeout())
+	})
+
+	t.Run("zero disables", func(t *testing.T) {
+		t.Setenv(cloudGrpcTimeoutEnvKey, "0s")
+		assert.Equal(t, int64(0), int64(cloudGrpcTimeout()))
+	})
+}
+
+func TestCloudDialOptions(t *testing.T) {
+	assert.NotEmpty(t, cloudDialOptions())
+}


### PR DESCRIPTION
Fixes #508.

The cloud gRPC clients were dialed with an empty set of options, so there was no default deadline and no per-call retry. If the control plane was briefly unavailable (for example during a scaling event) or a call hung, that surfaced as an immediate failure to the user.

This injects a small set of default dial options in `cloudClientConnection`:

- a default per-call timeout so a stuck RPC eventually errors instead of hanging
- retry of `UNAVAILABLE` with exponential backoff, which covers the transient "no ready backend" window during scaling
- bounded reconnect backoff (`WithConnectParams`) so a client recovers quickly once the backend is healthy again, rather than sitting in the default multi-minute backoff

The happy path is unchanged. Retries only kick in for `UNAVAILABLE`, which means the RPC never reached a serving backend, so this is safe for the non-idempotent calls too.

Both knobs have sensible defaults (4 attempts, 30s timeout) and can be tuned or disabled with `VET_CLOUD_GRPC_MAX_ATTEMPTS` (1 disables retries) and `VET_CLOUD_GRPC_TIMEOUT` (`0s` disables the deadline).

Added tests validate the generated service config against gRPC and cover the env parsing, clamping, and disable paths. `go test ./internal/auth/...`, `go vet`, and `golangci-lint run` are clean.
